### PR TITLE
Updating participants for campaigns and personas

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@
 .DS_Store?
 Thumbs.db
 /node_modules
+/prodaq/config.codekit

--- a/prodaq/library/_prodaq/campaign/_participants.php
+++ b/prodaq/library/_prodaq/campaign/_participants.php
@@ -1,36 +1,60 @@
 <div class="form-section">
-	<p><em>Long story short, we still need to pull in participants here in order for campaigns to be searchable by participant.</em></p>
-	<div class="form-group">
-		<?php $mb->the_field('participants', WPALCHEMY_FIELD_HINT_SELECT_MULTI); ?>
-		<label>Participants</label>
-		<select name="<?php $mb->the_name(); ?>" class="selectnice" multiple>
-			<?php
-				global $post;
-				$real_post = $post;
-				$args = array(
-					'post_type' => 'participant',
-					'post_status' => 'publish',
-					'orderby'=> 'title',
-					'order' => 'ASC',
-					'posts_per_page' => -1,
-					'caller_get_posts'=> 1
-				);
-				$my_query = null;
-				$my_query = new WP_Query($args);
-				if( $my_query->have_posts() ) {
-					while ($my_query->have_posts()) : $my_query->the_post();
-						$name = $post->post_title;
-						$company = get_post_meta($post->ID, '_participant_company', true);
-						$title = get_post_meta($post->ID, '_participant_title', true);
-						// since this is only for search purposes, storing more complex value to hit more queries to link to campaign.. must use explode() or strtok() in order to get just name for grabbing post
-						$value = $name . ' - ' . $company . ' - ' . $title;
-					?>
-						<option value="<?php echo $value; ?>"<?php $mb->the_select_state($value); ?>><?php echo $post->post_title; ?></option>
-					<?php	endwhile;
-				}
-				wp_reset_query();
-				$post = $real_post;
-			?>
-		</select>
+	<h4>Participants interviewed in  <?php echo the_title(); ?></h4>
+	<div class="participants">
+		<ul class="participants__list">
+
+		<?php
+			global $post;
+			$real_post = $post;
+			$args = array(
+				'post_type' => 'participant',
+				'post_status' => 'publish',
+				'orderby'=> 'title',
+				'order' => 'ASC',
+				'posts_per_page' => -1,
+				'caller_get_posts'=> 1
+			);
+			$my_query = null;
+			$my_query = new WP_Query($args);
+			$participantArr = array();
+			$participantCount = 0;
+
+
+			if( $my_query->have_posts() ) {
+				while ($my_query->have_posts()) : $my_query->the_post();
+					$meetings = get_post_meta($post->ID, '_participant_meetings', true);
+
+					// for each meeting, if a interview campaign matches this one, add to the array
+					foreach($meetings as $meeting){
+						if($meeting['interview_campaign'] == $real_post->ID){
+
+							// since this is only for search purposes, storing more complex value to hit more queries to link to campaign.. must use explode() or strtok() in order to get just name for grabbing post
+							$name = $post->post_title;
+							$company = get_post_meta($post->ID, '_participant_company', true);
+							$title = get_post_meta($post->ID, '_participant_title', true);
+							$value = $name . ' - ' . $company . ' - ' . $title;
+							if(!(in_array($value, $participantArr))){
+								array_push($participantArr, $value);
+								$participantCount ++;
+
+								echo '<li>
+									<a href="post.php?post=' . $post->ID . '&action=edit">' . $name . '</a>
+									<p>' . $company . ' - ' . $title . '</p>
+									</li>';
+								if($participantCount % 20 === 0){
+									echo '</ul><ul class="participants__list">';
+								}
+							}
+						}
+					}
+				?>
+
+				<?php	endwhile;
+			}
+			wp_reset_query();
+			$post = $real_post;
+			update_post_meta($post->ID, '_campaign_participants', $participantArr);
+		?>
+		</ul>
 	</div>
 </div>

--- a/prodaq/library/_prodaq/persona/_general.php
+++ b/prodaq/library/_prodaq/persona/_general.php
@@ -55,33 +55,7 @@
 				<?php $mb->the_field('summary'); ?>
 				<textarea class="ckeditor" id="personaSummary" name="<?php $mb->the_name(); ?>" rows="15"><?php $mb->the_value(); ?></textarea>
 			</div>
-			<div class="form-group">
-				<?php $mb->the_field('participants', WPALCHEMY_FIELD_HINT_SELECT_MULTI); ?>
-				<label>Associated Participant</label>
-				<select name="<?php $mb->the_name(); ?>" class="selectnice" multiple>
-					<?php
-						global $post;
-						$real_post = $post;
-						$args = array(
-							'post_type' => 'participant',
-							'post_status' => 'publish',
-							'orderby'=> 'title',
-							'order' => 'ASC',
-							'posts_per_page' => -1,
-							'caller_get_posts'=> 1
-						);
-						$my_query = null;
-						$my_query = new WP_Query($args);
-						if( $my_query->have_posts() ) {
-							while ($my_query->have_posts()) : $my_query->the_post();?>
-								<option value="<?php echo $post->ID; ?>"<?php $mb->the_select_state($post->ID); ?>><?php echo $post->post_title; ?></option>
-							<?php	endwhile;
-						}
-						wp_reset_query();
-						$post = $real_post;
-					?>
-				</select>
-			</div>
+			
 		</div>
 
 	</div>

--- a/prodaq/library/_prodaq/persona/_participants.php
+++ b/prodaq/library/_prodaq/persona/_participants.php
@@ -1,0 +1,55 @@
+<div class="form-section">
+	<div class="form-group">
+		<div class="participants">
+			<h4>Participants based on <?php echo the_title(); ?></h4>
+			<ul class="participants__list">
+
+			<?php
+				global $post;
+				$real_post = $post;
+				$args = array(
+					'post_type' => 'participant',
+					'post_status' => 'publish',
+					'orderby'=> 'title',
+					'order' => 'ASC',
+					'posts_per_page' => -1,
+					'caller_get_posts'=> 1
+				);
+				$my_query = null;
+				$my_query = new WP_Query($args);
+				$participantArr = array();
+				$participantCount = 0;
+				if( $my_query->have_posts() ) {
+					while ($my_query->have_posts()) : $my_query->the_post();
+						$primary = get_post_meta($post->ID, '_participant_primary_persona', true);
+
+						// for each meeting, if a interview campaign matches this one, add to the array
+
+						if($primary == $real_post->ID){
+							$participantCount ++;
+							// since this is only for search purposes, storing more complex value to hit more queries to link to campaign.. must use explode() or strtok() in order to get just name for grabbing post
+							$name = $post->post_title;
+							$role = get_post_meta($post->ID, '_participant_title', true);
+							$company = get_post_meta($post->ID, '_participant_company', true);
+							array_push($participantArr, $post->ID);
+							echo '<li>
+								<a href="post.php?post=' . $post->ID . '&action=edit">' . $name . '</a>
+								<p>' . $company . ' - ' . $role . '</p>
+								</li>';
+							if($participantCount % 20 === 0){
+								echo '</ul><ul class="participants__list">';
+							}
+						}
+					?>
+
+					<?php	endwhile;
+				}
+				wp_reset_query();
+				$post = $real_post;
+				update_post_meta($post->ID, '_persona_participants', $participantArr);
+			?>
+			</ul>
+
+		</div>
+	</div>
+</div>

--- a/prodaq/library/_prodaq/persona/persona-base.php
+++ b/prodaq/library/_prodaq/persona/persona-base.php
@@ -7,6 +7,7 @@
 	<li role="presentation"><a href="#goals" aria-controls="goals" role="tab" data-toggle="tab">Goals &amp; Pain Points</a></li>
 	<li role="presentation"><a href="#activities" aria-controls="activities" role="tab" data-toggle="tab">Activities &amp; Connections</a></li>
 	<li role="presentation"><a href="#notes" aria-controls="notes" role="tab" data-toggle="tab">Additional Notes</a></li>
+	<li role="presentation"><a href="#participants" aria-controls="notes" role="tab" data-toggle="tab">Participants</a></li>
 </ul>
 
 <div class="tab-content">
@@ -23,5 +24,7 @@
 	<div role="tabpanel" class="tab-pane" id="notes">
 			<?php include('_notes.php'); ?>
 	</div>
-
+	<div role="tabpanel" class="tab-pane" id="participants">
+			<?php include('_participants.php'); ?>
+	</div>
 </div>

--- a/prodaq/library/css/prodaq-admin.css
+++ b/prodaq/library/css/prodaq-admin.css
@@ -1,1 +1,1344 @@
-@charset "utf-8";@font-face{font-family:'SourceSansProRegular';font-style:normal;font-weight:normal;src:url('../fonts/font_sourcesans-pro/SourceSansPro-Regular-webfont.eot');src:url('../fonts/font_sourcesans-pro/SourceSansPro-Regular-webfont.eot?#iefix') format('embedded-opentype'),url('../fonts/font_sourcesans-pro/SourceSansPro-Regular-webfont.woff') format('woff'),url('../fonts/font_sourcesans-pro/SourceSansPro-Regular-webfont.ttf') format('truetype'),url('../fonts/font_sourcesans-pro/SourceSansPro-Regular-webfont.svg#SourceSansProRegular') format('svg')}@font-face{font-family:'SourceSansProBold';font-style:normal;font-weight:normal;src:url('../fonts/font_sourcesans-pro/SourceSansPro-Bold-webfont.eot');src:url('../fonts/font_sourcesans-pro/SourceSansPro-Bold-webfont.eot?#iefix') format('embedded-opentype'),url('../fonts/font_sourcesans-pro/SourceSansPro-Bold-webfont.woff') format('woff'),url('../fonts/font_sourcesans-pro/SourceSansPro-Bold-webfont.ttf') format('truetype'),url('../fonts/font_sourcesans-pro/SourceSansPro-Bold-webfont.svg#SourceSansProBold') format('svg')}@font-face{font-family:'SourceSansProLight';font-style:normal;font-weight:normal;src:url('../fonts/font_sourcesans-pro/SourceSansPro-Light-webfont.eot');src:url('../fonts/font_sourcesans-proSource/SansPro-Light-webfont.eot?#iefix') format('embedded-opentype'),url('../fonts/font_sourcesans-pro/SourceSansPro-Light-webfont.woff') format('woff'),url('../fonts/font_sourcesans-pro/SourceSansPro-Light-webfont.ttf') format('truetype'),url('../fonts/font_sourcesans-proSource/SansPro-Light-webfont.svg#SourceSansProLight') format('svg')}@font-face{font-family:'SourceSansProSemibold';font-style:normal;font-weight:normal;src:url('../fonts/font_sourcesans-pro/SourceSansPro-Semibold-webfont.eot');src:url('../fonts/font_sourcesans-pro/SourceSansPro-Semibold-webfont.eot?#iefix') format('embedded-opentype'),url('../fonts/font_sourcesans-pro/SourceSansPro-Semibold-webfont.woff') format('woff'),url('../fonts/font_sourcesans-pro/SourceSansPro-Semibold-webfont.ttf') format('truetype'),url('../fonts/font_sourcesans-pro/SourceSansPro-Semibold-webfont.svg#SourceSansProSemibold') format('svg')}/*! fileicon.css v1.0.0 | MIT License | github.com/picturepan2/fileicon.css */.file-icon{font-family:Arial,Tahoma,sans-serif;font-weight:300;display:block;width:24px;height:32px;background:#018FEF;position:relative;border-radius:2px;text-align:left;-webkit-font-smoothing:antialiased}.file-icon::before{display:block;content:"";position:absolute;top:0;right:0;width:0;height:0;border-bottom-left-radius:2px;border-width:5px;border-style:solid;border-color:#fff #fff rgba(255,255,255,0.35) rgba(255,255,255,0.35)}.file-icon::after{display:block;content:attr(data-type);position:absolute;bottom:0;left:0;font-size:10px;color:#fff;text-transform:lowercase;width:100%;padding:2px;white-space:nowrap;overflow:hidden}.file-icon-xs{width:12px;height:16px;border-radius:2px}.file-icon-xs::before{border-bottom-left-radius:1px;border-width:3px}.file-icon-xs::after{content:"";border-bottom:2px solid rgba(255,255,255,0.45);width:auto;left:2px;right:2px;bottom:3px}.file-icon-sm{width:18px;height:24px;border-radius:2px}.file-icon-sm::before{border-bottom-left-radius:2px;border-width:4px}.file-icon-sm::after{font-size:7px;padding:2px}.file-icon-lg{width:48px;height:64px;border-radius:3px}.file-icon-lg::before{border-bottom-left-radius:2px;border-width:8px}.file-icon-lg::after{font-size:16px;padding:4px 6px}.file-icon-xl{width:96px;height:128px;border-radius:4px}.file-icon-xl::before{border-bottom-left-radius:4px;border-width:16px}.file-icon-xl::after{font-size:24px;padding:4px 10px}.file-icon[data-type=zip],.file-icon[data-type=rar]{background:#ACACAC}.file-icon[data-type^=doc]{background:#307CF1}.file-icon[data-type^=xls]{background:#0F9D58}.file-icon[data-type^=ppt]{background:#D24726}.file-icon[data-type=pdf]{background:#E13D34}.file-icon[data-type=txt]{background:#5EB533}.file-icon[data-type=mp3],.file-icon[data-type=wma],.file-icon[data-type=m4a],.file-icon[data-type=flac]{background:#8E44AD}.file-icon[data-type=mp4],.file-icon[data-type=wmv],.file-icon[data-type=mov],.file-icon[data-type=avi],.file-icon[data-type=mkv]{background:#7A3CE7}.file-icon[data-type=bmp],.file-icon[data-type=jpg],.file-icon[data-type=jpeg],.file-icon[data-type=gif],.file-icon[data-type=png]{background:#F4B400}@font-face{font-family:'SSStandard';src:url('../fonts/font_ss-standard/ss-standard.eot');src:url('../fonts/font_ss-standard/ss-standard.eot?#iefix') format('embedded-opentype'),url('../fonts/font_ss-standard/ss-standard.woff') format('woff'),url('../fonts/font_ss-standard/ss-standard.ttf') format('truetype'),url('../fonts/font_ss-standard/ss-standard.svg#SourceSansProSemibold') format('svg');font-weight:normal;font-style:normal}@font-face{font-family:'SSSymbol';src:url('../fonts/font_ss-block/ss-symbolicons-block.eot');src:url('../fonts/font_ss-block/ss-symbolicons-block.eot?#iefix') format('embedded-opentype'),url('../fonts/font_ss-block/ss-symbolicons-block.woff') format('woff'),url('../fonts/font_ss-block/ss-symbolicons-block.ttf') format('truetype'),url('../fonts/font_ss-block/ss-symbolicons-block.svg#SourceSansProSemibold') format('svg');font-weight:normal;font-style:normal}@font-face{font-family:'SSSymbolOutline';src:url('../fonts/font_ss-line/ss-symbolicons-line.eot');src:url('../fonts/font_ss-line/ss-symbolicons-line.eot?#iefix') format('embedded-opentype'),url('../fonts/font_ss-line/ss-symbolicons-line.woff') format('woff'),url('../fonts/font_ss-line/ss-symbolicons-line.ttf') format('truetype'),url('../fonts/font_ss-line/ss-symbolicons-line.svg#SSSymbolOutline') format('svg');font-weight:normal;font-style:normal}@font-face{font-family:'SSGlyphishOutlined';src:url('../fonts/font_ss-glyphish-outlined/ss-glyphish-outlined.eot');src:url('../fonts/font_ss-glyphish-outlined/ss-glyphish-outlined.eot?#iefix') format('embedded-opentype'),url('../fonts/font_ss-glyphish-outlined/ss-glyphish-outlined.woff') format('woff'),url('../fonts/font_ss-glyphish-outlined/ss-glyphish-outlined.ttf') format('truetype'),url('../fonts/font_ss-glyphish-outlined/ss-glyphish-outlined.svg#SSSymbolOutline') format('svg');font-weight:normal;font-style:normal}@font-face{font-family:'SSSocial';src:url('../fonts/font_ss-social/ss-social-regular.eot');src:url('../fonts/font_ss-social/ss-social-regular.eot?#iefix') format('embedded-opentype'),url('../fonts/font_ss-social/ss-social-regular.woff') format('woff'),url('../fonts/font_ss-social/ss-social-regular.ttf') format('truetype'),url('../fonts/font_ss-social/ss-social-regular.svg#SSSocialRegular') format('svg');font-weight:normal;font-style:normal}.icon{font-family:"SSStandard";font-style:normal;font-weight:normal;text-decoration:none;text-rendering:optimizeLegibility;white-space:nowrap;-webkit-font-feature-settings:"liga";-moz-font-feature-settings:"liga=1";-moz-font-feature-settings:"liga";-ms-font-feature-settings:"liga" 1;-o-font-feature-settings:"liga";font-feature-settings:"liga";-webkit-font-smoothing:antialiased}.icon:before{content:attr(data-icon)}.icon.icon.symbol{font-family:"SSSymbol"}.icon.icon.symbol_outline{font-family:"SSSymbolOutline"}.icon.icon.social{font-family:"SSSocial"}.icon.icon.glyph{font-family:"SSGlyphishOutlined"}@-webkit-keyframes fadeAfterDisplay{0%{display:none;opacity:0}1%{display:inline-block;opacity:0}100%{display:inline-block;opacity:1}}.postbox .nav-tabs{background:#00bce3;padding-top:10px}.postbox .nav-tabs li a{border:0;font-size:16px;margin-right:0;padding:15px;-webkit-border-radius:0;-moz-border-radius:0;border-radius:0;color:#00687d}.postbox .nav-tabs li a:hover{background:none;color:#fff}.postbox .nav-tabs li a:focus{outline:none;background:transparent;box-shadow:none}.postbox .nav-tabs li.pull-right{margin-right:15px;color:#fff}.postbox .nav-tabs li.pull-right .checkbox{margin:15px 0 0}.postbox .nav-tabs li.pull-right .checkbox label{font-size:16px}.postbox .nav-tabs li.pull-right .checkbox label input{margin-top:2px}.postbox .nav-tabs li.active a{border:0;color:#fff;background:transparent}.postbox .nav-tabs li.active a:focus{outline:none;background:transparent;box-shadow:none}.postbox .nav-tabs li.active:focus{outline:none;box-shadow:none}.postbox .modal-content{background:#fff}.modal-annotation .modal-dialog{margin-top:120px}.modal-annotation .modal-dialog .modal-content{background:#2f333b;-webkit-border-radius:0;-moz-border-radius:0;border-radius:0}.modal-annotation .modal-dialog .modal-content .modal-body{background:#f3f3f3}.modal-annotation .modal-dialog .modal-content input{display:block;width:100%;padding:10px;margin-bottom:5px}.modal-annotation .modal-dialog .modal-content textarea{width:100%;padding:10px}.modal-annotation .modal-dialog .modal-content .btn-primary{background:#00bce3}#prodaq_documentation_widget{background:#2f333b}#prodaq_documentation_widget .inside{padding:0;margin:0}#prodaq_documentation_widget .prodaq-widget{overflow:auto}#prodaq_documentation_widget .prodaq-widget__nav{box-sizing:border-box;float:left;width:25%;color:#fff;border-right:1px solid #3a3f49}#prodaq_documentation_widget .prodaq-widget__nav>li{color:#00bce3;margin-bottom:5px;font-size:12px}#prodaq_documentation_widget .prodaq-widget__nav>li span{padding:5px 5px 5px 15px;text-transform:uppercase}#prodaq_documentation_widget .prodaq-widget__nav>li ul{padding:0;margin-top:5px}#prodaq_documentation_widget .prodaq-widget__nav>li ul li a{padding:5px 15px;display:block;color:#fff}#prodaq_documentation_widget .prodaq-widget__nav>li ul li a:hover{background:#3a3f49}#prodaq_documentation_widget .prodaq-widget__nav>li ul li.active a{background:#fff;color:#00bce3}#prodaq_documentation_widget .documentation__pane{width:75%;float:left;box-sizing:border-box;padding:15px;display:none}#prodaq_documentation_widget .documentation__pane.active{display:block}#prodaq_documentation_widget .documentation__pane h3{color:#fff}#prodaq_documentation_widget .documentation__pane p{color:#fff}#prodaq_documentation_widget .documentation__pane p a{color:#00bce3}#prodaq_documentation_widget .documentation__pane h2{color:#fff;font-size:18px}#prodaq_documentation_widget .documentation__pane span{color:#c272a9;background:#3a3f49;padding:0 2px;display:block}#prodaq_documentation_widget .documentation__pane h4{text-transform:uppercase;color:#fff}#prodaq_documentation_widget .documentation__pane .data-keys{height:250px;overflow-y:scroll;box-shadow:inset 0 -10px 15px -10px rgba(0,0,0,0.4)}#prodaq_documentation_widget .documentation__pane .data-keys li{color:#c272a9;margin-left:5px;margin-bottom:5px}#prodaq_documentation_widget .documentation__pane .data-keys li ul{margin-top:5px}#prodaq_documentation_widget .documentation__pane .data-keys li li{padding-left:10px;color:#a14685}#prodaq_documentation_widget .documentation__pane .data-keys li li li{color:#7d3768}#prodaq_documentation_widget .hndle.ui-sortable-handle{color:#fff;border-bottom:1px solid #3a3f49}#prodaq_dashboard_widget{background:#00bce3;position:relative;overflow:visible}#prodaq_dashboard_widget h3{color:#fff;border-bottom:1px solid #0092b0}#prodaq_dashboard_widget .prodaq-widget{transition:all 0.25s ease}#prodaq_dashboard_widget .prodaq-widget h2{color:#fff}#prodaq_dashboard_widget .prodaq-widget p{color:#fff;margin-bottom:25px}#prodaq_dashboard_widget .prodaq-widget>a{padding:10px 15px;border:1px solid #fff;color:#fff}#prodaq_dashboard_widget .prodaq-widget>a:hover{background:#00d1fc}#prodaq_dashboard_widget .participant__search{width:100%}#prodaq_dashboard_widget .participant-list{position:relative;background:#f4f4f4;width:100%;margin-top:0;overflow-y:scroll;height:0;transition:all 0.25s ease;border-top:1px solid #00bce3}#prodaq_dashboard_widget .participant-list.show{height:150px}#prodaq_dashboard_widget .participant-list li{border-bottom:1px solid #eee;margin:0}#prodaq_dashboard_widget .participant-list li a{display:block;padding:10px}#prodaq_dashboard_widget .participant-list li:hover{background:#fafafa}#prodaq_dashboard_widget .participant-list li.no-results{padding:10px}#prodaq_dashboard_widget input{width:100%;padding:10px;margin:25px 0 0;border:0}#poststuff #_campaign_data_metabox,#poststuff #_iteration_data_metabox,#poststuff #_participant_data_metabox,#poststuff #_persona_data_metabox,#poststuff #_product_data_metabox,#poststuff #_report_data_metabox,#poststuff #_quotes_data_metabox,#poststuff #_resource_data_metabox{background:transparent}#poststuff #_campaign_data_metabox .inside,#poststuff #_iteration_data_metabox .inside,#poststuff #_participant_data_metabox .inside,#poststuff #_persona_data_metabox .inside,#poststuff #_product_data_metabox .inside,#poststuff #_report_data_metabox .inside,#poststuff #_quotes_data_metabox .inside,#poststuff #_resource_data_metabox .inside{padding:0;margin-top:0}#poststuff #_campaign_data_metabox .hndle.ui-sortable-handle,#poststuff #_iteration_data_metabox .hndle.ui-sortable-handle,#poststuff #_participant_data_metabox .hndle.ui-sortable-handle,#poststuff #_persona_data_metabox .hndle.ui-sortable-handle,#poststuff #_product_data_metabox .hndle.ui-sortable-handle,#poststuff #_report_data_metabox .hndle.ui-sortable-handle,#poststuff #_quotes_data_metabox .hndle.ui-sortable-handle,#poststuff #_resource_data_metabox .hndle.ui-sortable-handle{background:#00bce3;color:#fff;font-weight:normal;border-bottom:0;font-size:24px;font-weight:200;line-height:48px;padding-bottom:0}#poststuff #_campaign_data_metabox .form-section,#poststuff #_iteration_data_metabox .form-section,#poststuff #_participant_data_metabox .form-section,#poststuff #_persona_data_metabox .form-section,#poststuff #_product_data_metabox .form-section,#poststuff #_report_data_metabox .form-section,#poststuff #_quotes_data_metabox .form-section,#poststuff #_resource_data_metabox .form-section{margin:15px 0;padding:15px 15px 30px;border-bottom:5px solid #ccc;background:#fff}#poststuff #_campaign_data_metabox .form-section .form-section__flex,#poststuff #_iteration_data_metabox .form-section .form-section__flex,#poststuff #_participant_data_metabox .form-section .form-section__flex,#poststuff #_persona_data_metabox .form-section .form-section__flex,#poststuff #_product_data_metabox .form-section .form-section__flex,#poststuff #_report_data_metabox .form-section .form-section__flex,#poststuff #_quotes_data_metabox .form-section .form-section__flex,#poststuff #_resource_data_metabox .form-section .form-section__flex{display:flex;flex-direction:row}#poststuff #_campaign_data_metabox .form-section .form-section__flex .form-group,#poststuff #_iteration_data_metabox .form-section .form-section__flex .form-group,#poststuff #_participant_data_metabox .form-section .form-section__flex .form-group,#poststuff #_persona_data_metabox .form-section .form-section__flex .form-group,#poststuff #_product_data_metabox .form-section .form-section__flex .form-group,#poststuff #_report_data_metabox .form-section .form-section__flex .form-group,#poststuff #_quotes_data_metabox .form-section .form-section__flex .form-group,#poststuff #_resource_data_metabox .form-section .form-section__flex .form-group{justify-content:space-between;width:100%;padding:10px 20px 10px 0}#poststuff #_campaign_data_metabox .form-section .form-section__flex .form-group .checkbox,#poststuff #_iteration_data_metabox .form-section .form-section__flex .form-group .checkbox,#poststuff #_participant_data_metabox .form-section .form-section__flex .form-group .checkbox,#poststuff #_persona_data_metabox .form-section .form-section__flex .form-group .checkbox,#poststuff #_product_data_metabox .form-section .form-section__flex .form-group .checkbox,#poststuff #_report_data_metabox .form-section .form-section__flex .form-group .checkbox,#poststuff #_quotes_data_metabox .form-section .form-section__flex .form-group .checkbox,#poststuff #_resource_data_metabox .form-section .form-section__flex .form-group .checkbox{margin-top:30px}#poststuff #_campaign_data_metabox .form-section .form-section__flex .form-group .checkbox input,#poststuff #_iteration_data_metabox .form-section .form-section__flex .form-group .checkbox input,#poststuff #_participant_data_metabox .form-section .form-section__flex .form-group .checkbox input,#poststuff #_persona_data_metabox .form-section .form-section__flex .form-group .checkbox input,#poststuff #_product_data_metabox .form-section .form-section__flex .form-group .checkbox input,#poststuff #_report_data_metabox .form-section .form-section__flex .form-group .checkbox input,#poststuff #_quotes_data_metabox .form-section .form-section__flex .form-group .checkbox input,#poststuff #_resource_data_metabox .form-section .form-section__flex .form-group .checkbox input{margin-right:3px}#poststuff #_campaign_data_metabox .form-section .form-section__flex .dodelete,#poststuff #_iteration_data_metabox .form-section .form-section__flex .dodelete,#poststuff #_participant_data_metabox .form-section .form-section__flex .dodelete,#poststuff #_persona_data_metabox .form-section .form-section__flex .dodelete,#poststuff #_product_data_metabox .form-section .form-section__flex .dodelete,#poststuff #_report_data_metabox .form-section .form-section__flex .dodelete,#poststuff #_quotes_data_metabox .form-section .form-section__flex .dodelete,#poststuff #_resource_data_metabox .form-section .form-section__flex .dodelete{margin-top:30px}#poststuff #_campaign_data_metabox .form-section h2,#poststuff #_iteration_data_metabox .form-section h2,#poststuff #_participant_data_metabox .form-section h2,#poststuff #_persona_data_metabox .form-section h2,#poststuff #_product_data_metabox .form-section h2,#poststuff #_report_data_metabox .form-section h2,#poststuff #_quotes_data_metabox .form-section h2,#poststuff #_resource_data_metabox .form-section h2{color:#2f333b;margin-top:5px!important;padding:0;font-size:18px;line-height:30px}#poststuff #_campaign_data_metabox .form-section .dodelete,#poststuff #_iteration_data_metabox .form-section .dodelete,#poststuff #_participant_data_metabox .form-section .dodelete,#poststuff #_persona_data_metabox .form-section .dodelete,#poststuff #_product_data_metabox .form-section .dodelete,#poststuff #_report_data_metabox .form-section .dodelete,#poststuff #_quotes_data_metabox .form-section .dodelete,#poststuff #_resource_data_metabox .form-section .dodelete{position:absolute;right:15px;color:#ccc;line-height:40px}#poststuff #_campaign_data_metabox .form-section .dodelete:hover,#poststuff #_iteration_data_metabox .form-section .dodelete:hover,#poststuff #_participant_data_metabox .form-section .dodelete:hover,#poststuff #_persona_data_metabox .form-section .dodelete:hover,#poststuff #_product_data_metabox .form-section .dodelete:hover,#poststuff #_report_data_metabox .form-section .dodelete:hover,#poststuff #_quotes_data_metabox .form-section .dodelete:hover,#poststuff #_resource_data_metabox .form-section .dodelete:hover{color:#999;text-decoration:none}#poststuff #_campaign_data_metabox .form-section a[class^="docopy-"],#poststuff #_iteration_data_metabox .form-section a[class^="docopy-"],#poststuff #_participant_data_metabox .form-section a[class^="docopy-"],#poststuff #_persona_data_metabox .form-section a[class^="docopy-"],#poststuff #_product_data_metabox .form-section a[class^="docopy-"],#poststuff #_report_data_metabox .form-section a[class^="docopy-"],#poststuff #_quotes_data_metabox .form-section a[class^="docopy-"],#poststuff #_resource_data_metabox .form-section a[class^="docopy-"],#poststuff #_campaign_data_metabox .form-section a[class*=" docopy-"],#poststuff #_iteration_data_metabox .form-section a[class*=" docopy-"],#poststuff #_participant_data_metabox .form-section a[class*=" docopy-"],#poststuff #_persona_data_metabox .form-section a[class*=" docopy-"],#poststuff #_product_data_metabox .form-section a[class*=" docopy-"],#poststuff #_report_data_metabox .form-section a[class*=" docopy-"],#poststuff #_quotes_data_metabox .form-section a[class*=" docopy-"],#poststuff #_resource_data_metabox .form-section a[class*=" docopy-"]{width:100%;text-align:center;line-height:40px;height:40px}#poststuff #_campaign_data_metabox .form-section .form-group.upload-inline,#poststuff #_iteration_data_metabox .form-section .form-group.upload-inline,#poststuff #_participant_data_metabox .form-section .form-group.upload-inline,#poststuff #_persona_data_metabox .form-section .form-group.upload-inline,#poststuff #_product_data_metabox .form-section .form-group.upload-inline,#poststuff #_report_data_metabox .form-section .form-group.upload-inline,#poststuff #_quotes_data_metabox .form-section .form-group.upload-inline,#poststuff #_resource_data_metabox .form-section .form-group.upload-inline{width:100%}#poststuff #_campaign_data_metabox .form-section .form-group.upload-inline input[type="text"],#poststuff #_iteration_data_metabox .form-section .form-group.upload-inline input[type="text"],#poststuff #_participant_data_metabox .form-section .form-group.upload-inline input[type="text"],#poststuff #_persona_data_metabox .form-section .form-group.upload-inline input[type="text"],#poststuff #_product_data_metabox .form-section .form-group.upload-inline input[type="text"],#poststuff #_report_data_metabox .form-section .form-group.upload-inline input[type="text"],#poststuff #_quotes_data_metabox .form-section .form-group.upload-inline input[type="text"],#poststuff #_resource_data_metabox .form-section .form-group.upload-inline input[type="text"]{width:80%;display:inline-block}#poststuff #_campaign_data_metabox .form-section .form-group.upload-inline a,#poststuff #_iteration_data_metabox .form-section .form-group.upload-inline a,#poststuff #_participant_data_metabox .form-section .form-group.upload-inline a,#poststuff #_persona_data_metabox .form-section .form-group.upload-inline a,#poststuff #_product_data_metabox .form-section .form-group.upload-inline a,#poststuff #_report_data_metabox .form-section .form-group.upload-inline a,#poststuff #_quotes_data_metabox .form-section .form-group.upload-inline a,#poststuff #_resource_data_metabox .form-section .form-group.upload-inline a{width:19%;text-align:center;display:inline-block;min-height:36px;line-height:36px}#poststuff #_campaign_data_metabox .form-section .asset-repeatable,#poststuff #_iteration_data_metabox .form-section .asset-repeatable,#poststuff #_participant_data_metabox .form-section .asset-repeatable,#poststuff #_persona_data_metabox .form-section .asset-repeatable,#poststuff #_product_data_metabox .form-section .asset-repeatable,#poststuff #_report_data_metabox .form-section .asset-repeatable,#poststuff #_quotes_data_metabox .form-section .asset-repeatable,#poststuff #_resource_data_metabox .form-section .asset-repeatable{border:1px solid #ccc;margin-bottom:15px;padding:15px;position:relative}#poststuff #_campaign_data_metabox .form-section .asset-repeatable .form-group,#poststuff #_iteration_data_metabox .form-section .asset-repeatable .form-group,#poststuff #_participant_data_metabox .form-section .asset-repeatable .form-group,#poststuff #_persona_data_metabox .form-section .asset-repeatable .form-group,#poststuff #_product_data_metabox .form-section .asset-repeatable .form-group,#poststuff #_report_data_metabox .form-section .asset-repeatable .form-group,#poststuff #_quotes_data_metabox .form-section .asset-repeatable .form-group,#poststuff #_resource_data_metabox .form-section .asset-repeatable .form-group{width:40%}#poststuff #_campaign_data_metabox .form-section .asset-repeatable .form-group.upload-inline input,#poststuff #_iteration_data_metabox .form-section .asset-repeatable .form-group.upload-inline input,#poststuff #_participant_data_metabox .form-section .asset-repeatable .form-group.upload-inline input,#poststuff #_persona_data_metabox .form-section .asset-repeatable .form-group.upload-inline input,#poststuff #_product_data_metabox .form-section .asset-repeatable .form-group.upload-inline input,#poststuff #_report_data_metabox .form-section .asset-repeatable .form-group.upload-inline input,#poststuff #_quotes_data_metabox .form-section .asset-repeatable .form-group.upload-inline input,#poststuff #_resource_data_metabox .form-section .asset-repeatable .form-group.upload-inline input{width:45%}#poststuff #_campaign_data_metabox .form-section .asset-repeatable .form-group.upload-inline a,#poststuff #_iteration_data_metabox .form-section .asset-repeatable .form-group.upload-inline a,#poststuff #_participant_data_metabox .form-section .asset-repeatable .form-group.upload-inline a,#poststuff #_persona_data_metabox .form-section .asset-repeatable .form-group.upload-inline a,#poststuff #_product_data_metabox .form-section .asset-repeatable .form-group.upload-inline a,#poststuff #_report_data_metabox .form-section .asset-repeatable .form-group.upload-inline a,#poststuff #_quotes_data_metabox .form-section .asset-repeatable .form-group.upload-inline a,#poststuff #_resource_data_metabox .form-section .asset-repeatable .form-group.upload-inline a{width:auto}#poststuff #_campaign_data_metabox .form-section .grid-repeatable,#poststuff #_iteration_data_metabox .form-section .grid-repeatable,#poststuff #_participant_data_metabox .form-section .grid-repeatable,#poststuff #_persona_data_metabox .form-section .grid-repeatable,#poststuff #_product_data_metabox .form-section .grid-repeatable,#poststuff #_report_data_metabox .form-section .grid-repeatable,#poststuff #_quotes_data_metabox .form-section .grid-repeatable,#poststuff #_resource_data_metabox .form-section .grid-repeatable{border:1px solid #ccc;margin-bottom:15px;padding:15px;position:relative}#poststuff #_campaign_data_metabox .form-section .grid-repeatable .dodelete,#poststuff #_iteration_data_metabox .form-section .grid-repeatable .dodelete,#poststuff #_participant_data_metabox .form-section .grid-repeatable .dodelete,#poststuff #_persona_data_metabox .form-section .grid-repeatable .dodelete,#poststuff #_product_data_metabox .form-section .grid-repeatable .dodelete,#poststuff #_report_data_metabox .form-section .grid-repeatable .dodelete,#poststuff #_quotes_data_metabox .form-section .grid-repeatable .dodelete,#poststuff #_resource_data_metabox .form-section .grid-repeatable .dodelete{top:0}#poststuff #_campaign_data_metabox .form-section .goal-repeatable .form-group input[type="text"],#poststuff #_iteration_data_metabox .form-section .goal-repeatable .form-group input[type="text"],#poststuff #_participant_data_metabox .form-section .goal-repeatable .form-group input[type="text"],#poststuff #_persona_data_metabox .form-section .goal-repeatable .form-group input[type="text"],#poststuff #_product_data_metabox .form-section .goal-repeatable .form-group input[type="text"],#poststuff #_report_data_metabox .form-section .goal-repeatable .form-group input[type="text"],#poststuff #_quotes_data_metabox .form-section .goal-repeatable .form-group input[type="text"],#poststuff #_resource_data_metabox .form-section .goal-repeatable .form-group input[type="text"]{width:95%}#poststuff #_campaign_data_metabox .form-section .ndaq-repeatable,#poststuff #_iteration_data_metabox .form-section .ndaq-repeatable,#poststuff #_participant_data_metabox .form-section .ndaq-repeatable,#poststuff #_persona_data_metabox .form-section .ndaq-repeatable,#poststuff #_product_data_metabox .form-section .ndaq-repeatable,#poststuff #_report_data_metabox .form-section .ndaq-repeatable,#poststuff #_quotes_data_metabox .form-section .ndaq-repeatable,#poststuff #_resource_data_metabox .form-section .ndaq-repeatable{border:1px solid #ccc;position:relative;margin-bottom:15px}#poststuff #_campaign_data_metabox .form-section .ndaq-repeatable .ndaq-repeatable__header,#poststuff #_iteration_data_metabox .form-section .ndaq-repeatable .ndaq-repeatable__header,#poststuff #_participant_data_metabox .form-section .ndaq-repeatable .ndaq-repeatable__header,#poststuff #_persona_data_metabox .form-section .ndaq-repeatable .ndaq-repeatable__header,#poststuff #_product_data_metabox .form-section .ndaq-repeatable .ndaq-repeatable__header,#poststuff #_report_data_metabox .form-section .ndaq-repeatable .ndaq-repeatable__header,#poststuff #_quotes_data_metabox .form-section .ndaq-repeatable .ndaq-repeatable__header,#poststuff #_resource_data_metabox .form-section .ndaq-repeatable .ndaq-repeatable__header{overflow:auto;padding:10px 15px;cursor:pointer;position:relative;z-index:100}#poststuff #_campaign_data_metabox .form-section .ndaq-repeatable .ndaq-repeatable__header h2,#poststuff #_iteration_data_metabox .form-section .ndaq-repeatable .ndaq-repeatable__header h2,#poststuff #_participant_data_metabox .form-section .ndaq-repeatable .ndaq-repeatable__header h2,#poststuff #_persona_data_metabox .form-section .ndaq-repeatable .ndaq-repeatable__header h2,#poststuff #_product_data_metabox .form-section .ndaq-repeatable .ndaq-repeatable__header h2,#poststuff #_report_data_metabox .form-section .ndaq-repeatable .ndaq-repeatable__header h2,#poststuff #_quotes_data_metabox .form-section .ndaq-repeatable .ndaq-repeatable__header h2,#poststuff #_resource_data_metabox .form-section .ndaq-repeatable .ndaq-repeatable__header h2{margin:0 15px 0 0!important;float:left;line-height:40px}#poststuff #_campaign_data_metabox .form-section .ndaq-repeatable .ndaq-repeatable__header .checkbox,#poststuff #_iteration_data_metabox .form-section .ndaq-repeatable .ndaq-repeatable__header .checkbox,#poststuff #_participant_data_metabox .form-section .ndaq-repeatable .ndaq-repeatable__header .checkbox,#poststuff #_persona_data_metabox .form-section .ndaq-repeatable .ndaq-repeatable__header .checkbox,#poststuff #_product_data_metabox .form-section .ndaq-repeatable .ndaq-repeatable__header .checkbox,#poststuff #_report_data_metabox .form-section .ndaq-repeatable .ndaq-repeatable__header .checkbox,#poststuff #_quotes_data_metabox .form-section .ndaq-repeatable .ndaq-repeatable__header .checkbox,#poststuff #_resource_data_metabox .form-section .ndaq-repeatable .ndaq-repeatable__header .checkbox{margin-top:12px}#poststuff #_campaign_data_metabox .form-section .ndaq-repeatable .ndaq-repeatable__header select,#poststuff #_iteration_data_metabox .form-section .ndaq-repeatable .ndaq-repeatable__header select,#poststuff #_participant_data_metabox .form-section .ndaq-repeatable .ndaq-repeatable__header select,#poststuff #_persona_data_metabox .form-section .ndaq-repeatable .ndaq-repeatable__header select,#poststuff #_product_data_metabox .form-section .ndaq-repeatable .ndaq-repeatable__header select,#poststuff #_report_data_metabox .form-section .ndaq-repeatable .ndaq-repeatable__header select,#poststuff #_quotes_data_metabox .form-section .ndaq-repeatable .ndaq-repeatable__header select,#poststuff #_resource_data_metabox .form-section .ndaq-repeatable .ndaq-repeatable__header select{margin-top:8px}#poststuff #_campaign_data_metabox .form-section .ndaq-repeatable .ndaq-repeatable__header input,#poststuff #_iteration_data_metabox .form-section .ndaq-repeatable .ndaq-repeatable__header input,#poststuff #_participant_data_metabox .form-section .ndaq-repeatable .ndaq-repeatable__header input,#poststuff #_persona_data_metabox .form-section .ndaq-repeatable .ndaq-repeatable__header input,#poststuff #_product_data_metabox .form-section .ndaq-repeatable .ndaq-repeatable__header input,#poststuff #_report_data_metabox .form-section .ndaq-repeatable .ndaq-repeatable__header input,#poststuff #_quotes_data_metabox .form-section .ndaq-repeatable .ndaq-repeatable__header input,#poststuff #_resource_data_metabox .form-section .ndaq-repeatable .ndaq-repeatable__header input{margin-top:8px}#poststuff #_campaign_data_metabox .form-section .ndaq-repeatable .ndaq-repeatable__header .form-group,#poststuff #_iteration_data_metabox .form-section .ndaq-repeatable .ndaq-repeatable__header .form-group,#poststuff #_participant_data_metabox .form-section .ndaq-repeatable .ndaq-repeatable__header .form-group,#poststuff #_persona_data_metabox .form-section .ndaq-repeatable .ndaq-repeatable__header .form-group,#poststuff #_product_data_metabox .form-section .ndaq-repeatable .ndaq-repeatable__header .form-group,#poststuff #_report_data_metabox .form-section .ndaq-repeatable .ndaq-repeatable__header .form-group,#poststuff #_quotes_data_metabox .form-section .ndaq-repeatable .ndaq-repeatable__header .form-group,#poststuff #_resource_data_metabox .form-section .ndaq-repeatable .ndaq-repeatable__header .form-group{margin:0 15px}#poststuff #_campaign_data_metabox .form-section .ndaq-repeatable .ndaq-repeatable__body,#poststuff #_iteration_data_metabox .form-section .ndaq-repeatable .ndaq-repeatable__body,#poststuff #_participant_data_metabox .form-section .ndaq-repeatable .ndaq-repeatable__body,#poststuff #_persona_data_metabox .form-section .ndaq-repeatable .ndaq-repeatable__body,#poststuff #_product_data_metabox .form-section .ndaq-repeatable .ndaq-repeatable__body,#poststuff #_report_data_metabox .form-section .ndaq-repeatable .ndaq-repeatable__body,#poststuff #_quotes_data_metabox .form-section .ndaq-repeatable .ndaq-repeatable__body,#poststuff #_resource_data_metabox .form-section .ndaq-repeatable .ndaq-repeatable__body{display:none;padding:25px 15px;background:#f4f4f7;border-top:1px solid #ccc}#poststuff #_campaign_data_metabox .form-section .ndaq-repeatable .ndaq-repeatable__body.active,#poststuff #_iteration_data_metabox .form-section .ndaq-repeatable .ndaq-repeatable__body.active,#poststuff #_participant_data_metabox .form-section .ndaq-repeatable .ndaq-repeatable__body.active,#poststuff #_persona_data_metabox .form-section .ndaq-repeatable .ndaq-repeatable__body.active,#poststuff #_product_data_metabox .form-section .ndaq-repeatable .ndaq-repeatable__body.active,#poststuff #_report_data_metabox .form-section .ndaq-repeatable .ndaq-repeatable__body.active,#poststuff #_quotes_data_metabox .form-section .ndaq-repeatable .ndaq-repeatable__body.active,#poststuff #_resource_data_metabox .form-section .ndaq-repeatable .ndaq-repeatable__body.active{display:block}#poststuff #_campaign_data_metabox .form-section .ndaq-repeatable .ndaq-repeatable__body .col-md-5 .upload-inline input,#poststuff #_iteration_data_metabox .form-section .ndaq-repeatable .ndaq-repeatable__body .col-md-5 .upload-inline input,#poststuff #_participant_data_metabox .form-section .ndaq-repeatable .ndaq-repeatable__body .col-md-5 .upload-inline input,#poststuff #_persona_data_metabox .form-section .ndaq-repeatable .ndaq-repeatable__body .col-md-5 .upload-inline input,#poststuff #_product_data_metabox .form-section .ndaq-repeatable .ndaq-repeatable__body .col-md-5 .upload-inline input,#poststuff #_report_data_metabox .form-section .ndaq-repeatable .ndaq-repeatable__body .col-md-5 .upload-inline input,#poststuff #_quotes_data_metabox .form-section .ndaq-repeatable .ndaq-repeatable__body .col-md-5 .upload-inline input,#poststuff #_resource_data_metabox .form-section .ndaq-repeatable .ndaq-repeatable__body .col-md-5 .upload-inline input{width:54%}#poststuff #_campaign_data_metabox .form-section .ndaq-repeatable .ndaq-repeatable__body .col-md-5 .upload-inline a,#poststuff #_iteration_data_metabox .form-section .ndaq-repeatable .ndaq-repeatable__body .col-md-5 .upload-inline a,#poststuff #_participant_data_metabox .form-section .ndaq-repeatable .ndaq-repeatable__body .col-md-5 .upload-inline a,#poststuff #_persona_data_metabox .form-section .ndaq-repeatable .ndaq-repeatable__body .col-md-5 .upload-inline a,#poststuff #_product_data_metabox .form-section .ndaq-repeatable .ndaq-repeatable__body .col-md-5 .upload-inline a,#poststuff #_report_data_metabox .form-section .ndaq-repeatable .ndaq-repeatable__body .col-md-5 .upload-inline a,#poststuff #_quotes_data_metabox .form-section .ndaq-repeatable .ndaq-repeatable__body .col-md-5 .upload-inline a,#poststuff #_resource_data_metabox .form-section .ndaq-repeatable .ndaq-repeatable__body .col-md-5 .upload-inline a{width:auto}#poststuff #_campaign_data_metabox .form-section .form-group label,#poststuff #_iteration_data_metabox .form-section .form-group label,#poststuff #_participant_data_metabox .form-section .form-group label,#poststuff #_persona_data_metabox .form-section .form-group label,#poststuff #_product_data_metabox .form-section .form-group label,#poststuff #_report_data_metabox .form-section .form-group label,#poststuff #_quotes_data_metabox .form-section .form-group label,#poststuff #_resource_data_metabox .form-section .form-group label{display:block}#poststuff #_campaign_data_metabox .form-section .form-group textarea,#poststuff #_iteration_data_metabox .form-section .form-group textarea,#poststuff #_participant_data_metabox .form-section .form-group textarea,#poststuff #_persona_data_metabox .form-section .form-group textarea,#poststuff #_product_data_metabox .form-section .form-group textarea,#poststuff #_report_data_metabox .form-section .form-group textarea,#poststuff #_quotes_data_metabox .form-section .form-group textarea,#poststuff #_resource_data_metabox .form-section .form-group textarea,#poststuff #_campaign_data_metabox .form-section .form-group input[type="text"],#poststuff #_iteration_data_metabox .form-section .form-group input[type="text"],#poststuff #_participant_data_metabox .form-section .form-group input[type="text"],#poststuff #_persona_data_metabox .form-section .form-group input[type="text"],#poststuff #_product_data_metabox .form-section .form-group input[type="text"],#poststuff #_report_data_metabox .form-section .form-group input[type="text"],#poststuff #_quotes_data_metabox .form-section .form-group input[type="text"],#poststuff #_resource_data_metabox .form-section .form-group input[type="text"]{width:100%}#poststuff #_campaign_data_metabox .form-section .form-group input[type="text"],#poststuff #_iteration_data_metabox .form-section .form-group input[type="text"],#poststuff #_participant_data_metabox .form-section .form-group input[type="text"],#poststuff #_persona_data_metabox .form-section .form-group input[type="text"],#poststuff #_product_data_metabox .form-section .form-group input[type="text"],#poststuff #_report_data_metabox .form-section .form-group input[type="text"],#poststuff #_quotes_data_metabox .form-section .form-group input[type="text"],#poststuff #_resource_data_metabox .form-section .form-group input[type="text"]{padding:8px}#poststuff #_campaign_data_metabox .form-section .form-group .checkbox input,#poststuff #_iteration_data_metabox .form-section .form-group .checkbox input,#poststuff #_participant_data_metabox .form-section .form-group .checkbox input,#poststuff #_persona_data_metabox .form-section .form-group .checkbox input,#poststuff #_product_data_metabox .form-section .form-group .checkbox input,#poststuff #_report_data_metabox .form-section .form-group .checkbox input,#poststuff #_quotes_data_metabox .form-section .form-group .checkbox input,#poststuff #_resource_data_metabox .form-section .form-group .checkbox input{margin-top:0}#poststuff #_campaign_data_metabox .form-section .form-group .thumb-container,#poststuff #_iteration_data_metabox .form-section .form-group .thumb-container,#poststuff #_participant_data_metabox .form-section .form-group .thumb-container,#poststuff #_persona_data_metabox .form-section .form-group .thumb-container,#poststuff #_product_data_metabox .form-section .form-group .thumb-container,#poststuff #_report_data_metabox .form-section .form-group .thumb-container,#poststuff #_quotes_data_metabox .form-section .form-group .thumb-container,#poststuff #_resource_data_metabox .form-section .form-group .thumb-container{width:50px;height:50px;margin:5px 0;border:1px solid #ccc}#poststuff #_campaign_data_metabox .form-section .form-group .thumb-container img,#poststuff #_iteration_data_metabox .form-section .form-group .thumb-container img,#poststuff #_participant_data_metabox .form-section .form-group .thumb-container img,#poststuff #_persona_data_metabox .form-section .form-group .thumb-container img,#poststuff #_product_data_metabox .form-section .form-group .thumb-container img,#poststuff #_report_data_metabox .form-section .form-group .thumb-container img,#poststuff #_quotes_data_metabox .form-section .form-group .thumb-container img,#poststuff #_resource_data_metabox .form-section .form-group .thumb-container img{width:100%}#poststuff #_campaign_data_metabox .form-section .select2-container,#poststuff #_iteration_data_metabox .form-section .select2-container,#poststuff #_participant_data_metabox .form-section .select2-container,#poststuff #_persona_data_metabox .form-section .select2-container,#poststuff #_product_data_metabox .form-section .select2-container,#poststuff #_report_data_metabox .form-section .select2-container,#poststuff #_quotes_data_metabox .form-section .select2-container,#poststuff #_resource_data_metabox .form-section .select2-container{width:100%}#poststuff #_campaign_data_metabox .form-section .select2-container input[type="text"],#poststuff #_iteration_data_metabox .form-section .select2-container input[type="text"],#poststuff #_participant_data_metabox .form-section .select2-container input[type="text"],#poststuff #_persona_data_metabox .form-section .select2-container input[type="text"],#poststuff #_product_data_metabox .form-section .select2-container input[type="text"],#poststuff #_report_data_metabox .form-section .select2-container input[type="text"],#poststuff #_quotes_data_metabox .form-section .select2-container input[type="text"],#poststuff #_resource_data_metabox .form-section .select2-container input[type="text"]{padding:5px}#poststuff #_campaign_data_metabox .form-section .select2-container .select2-choice abbr,#poststuff #_iteration_data_metabox .form-section .select2-container .select2-choice abbr,#poststuff #_participant_data_metabox .form-section .select2-container .select2-choice abbr,#poststuff #_persona_data_metabox .form-section .select2-container .select2-choice abbr,#poststuff #_product_data_metabox .form-section .select2-container .select2-choice abbr,#poststuff #_report_data_metabox .form-section .select2-container .select2-choice abbr,#poststuff #_quotes_data_metabox .form-section .select2-container .select2-choice abbr,#poststuff #_resource_data_metabox .form-section .select2-container .select2-choice abbr{right:35px;top:9px}#poststuff .row-with-thumb{border-top:1px solid #ccc;padding:10px 0;background:#fafafa}#poststuff .row-with-thumb:last-of-type{border-bottom:1px solid #ccc;margin-bottom:15px}#poststuff .row-with-thumb .hidden-input{width:100%;position:relative}#poststuff .row-with-thumb .hidden-input a{position:absolute;width:100%;top:0;box-sizing:border-box;text-align:center;line-height:36px;height:36px}#poststuff .row-with-thumb .hidden-input input{position:absolute;top:0;border:0}#poststuff .row-with-thumb .hidden-input .preview-wrapper{margin-top:25px}#poststuff .preview-wrapper{position:relative}#poststuff .preview-wrapper img{width:100%}#poststuff .target{position:absolute;height:40px;width:40px;border:4px dashed #e223db}#poststuff .target a{background:#2f333b;border-bottom:1px solid #fff;color:#fff;padding:5px;width:auto!important;line-height:15px!important;min-height:15px!important;position:relative;display:block!important;right:-38px;top:-8px;text-align:center}#poststuff .target a:hover{color:#e223db}#poststuff .target a:last-of-type{border:none}#poststuff .target a.remove{bottom:0}#poststuff .annotationArr:read-only{background:#2f333b;border:none;color:#515866;padding:10px}#_iteration_data_metabox .inside{padding:0;margin:0}#_iteration_data_metabox .iteration__header{background:#f4f4f5;padding:15px;border-bottom:1px solid #ccc;position:relative}#_iteration_data_metabox .iteration__header .form-group{margin:0}#_iteration_data_metabox .iteration__header .form-group .select2-container{width:200px;margin-left:15px}#_iteration_data_metabox .iteration__header a.help{position:absolute;right:10px;top:20px;display:block;width:24px;height:24px;text-align:center;line-height:24px;background:#96979c;-webkit-border-radius:50%;-moz-border-radius:50%;border-radius:50%;color:#fff}#_iteration_data_metabox .iteration__pane{display:none}#_iteration_data_metabox .iteration__pane.active{display:block}#_iteration_data_metabox .iteration__pane h2{padding-left:0;font-size:18px}#_iteration_data_metabox .iteration__pane .docopy-images{width:100%;box-shadow:none;line-height:40px;height:40px;text-align:center}#_iteration_data_metabox .iteration__pane .form-section{position:relative}#_iteration_data_metabox .iteration__pane .form-section .dodelete{top:0;right:0!important;font-size:16px;background:#6b6d75;width:30px;text-align:center;line-height:30px!important;height:30px}#_iteration_data_metabox .iteration__pane .form-section .preview-wrapper{margin-top:10px}#_iteration_data_metabox .iteration__pane .form-section .form-group{margin-top:15px}#_iteration_data_metabox .iteration__pane.iteration__element{padding:0}#_iteration_data_metabox .iteration__pane.iteration__element .nav-tabs{padding-top:0}#_iteration_data_metabox .iteration__pane.iteration__element .nav-tabs li.active a{border-top:0}#iteration-help .modal-body ul>li{margin:10px 0}#iteration-help .modal-body ul>li>ul{padding-left:20px}#_product_data_metabox .download-template li{display:none;padding:15px 0;font-size:16px}#_product_data_metabox .download-template li img{margin-right:5px}#_product_data_metabox .download-template li.active{display:block}#_report_data_metabox #images .form-section{position:relative}#_report_data_metabox #images .form-section .dodelete{top:0;right:0!important;font-size:14px;background:#6b6d75;width:30px;text-align:center;line-height:30px!important;height:30px}#_report_data_metabox #images .form-section .preview-wrapper{margin-top:10px}#_report_data_metabox #images .form-section .form-group{margin-top:15px}#_report_data_metabox #images .docopy-images{width:100%;box-shadow:none;line-height:40px;height:40px;text-align:center}#_resource_data_metabox .ndaq-repeatable__header .form-group{margin-left:0;margin-right:50px}#_resource_data_metabox .ndaq-repeatable__header .form-group input{margin-top:0}#_resource_data_metabox .ndaq-repeatable__header .dodelete{top:10px}html,body{background:#e3e6ed}.post-type-participant .wp-list-table .column-featured_image,.post-type-persona .wp-list-table .column-featured_image{width:100px}#adminmenuback,#adminmenu,#adminmenuwrap{background-color:#2d303a}#wp-content-editor-tools{background:#e3e6ed}#dashboard-widgets-wrap{overflow:visible}#adminmenu li.wp-has-current-submenu .wp-submenu{background-color:#1d1f25}#adminmenu li.wp-has-current-submenu a.wp-has-current-submenu{background:#1d1f25;color:#00bce3}#adminmenu .menu-icon-persona{background:#262930}#adminmenu .menu-icon-persona div.wp-menu-image:before{content:"\f337";color:#00bce3}#adminmenu .menu-icon-campaign{background:#262930}#adminmenu .menu-icon-campaign div.wp-menu-image:before{content:"\f183";color:#00bce3}#adminmenu .menu-icon-question{background:#262930}#adminmenu .menu-icon-question div.wp-menu-image:before{content:"\f130";color:#00bce3}#adminmenu .menu-icon-product{background:#262930}#adminmenu .menu-icon-product div.wp-menu-image:before{content:"\f115";color:#00bce3}#adminmenu .menu-icon-report{background:#262930;border-bottom:1px solid #1d1f24}#adminmenu .menu-icon-report div.wp-menu-image:before{content:"\f180";color:#00bce3}#adminmenu .menu-icon-quote{background:#262930;border-bottom:1px solid #1d1f24}#adminmenu .menu-icon-quote div.wp-menu-image:before{content:"\f122";color:#00bce3}#adminmenu li.menu-icon-participant{background:#262930;border-top:1px solid #1d1f24;margin-top:10px}#adminmenu li.menu-icon-participant div.wp-menu-image:before{content:"\f307";color:#00bce3}#adminmenu li.menu-icon-iteration{background:#262930}#adminmenu li.menu-icon-iteration div.wp-menu-image:before{content:"\f232";color:#00bce3}#wpadminbar{background:#2d303a}.select2-results .select2-no-results{background:#2d303a}.select2-search-choice-close{background-image:none!important}.select2-search{background-image:none!important}.tpx-select2-container.select2-daq .select2-choice{border-color:#2d303a;background-color:#2d303a;box-shadow:none;color:#fff}.tpx-select2-container.select2-daq .select2-choice .select2-arrow{border-left-color:#2d303a;background-color:#2d303a;color:#fff}.tpx-select2-container.select2-daq .select2-default .select2-chosen{color:rgba(255,255,255,0.5)}.tpx-select2-container.select2-daq.select2-container-multi .select2-choices .select2-search-choice{border-color:#22242c;background-color:#2d303a;color:#fff}.tpx-select2-container.select2-daq.select2-container-multi .select2-choices .select2-search-choice:before{color:rgba(255,255,255,0.5)}.tpx-select2-container.select2-daq.select2-container-active .select2-choice{border-color:#1d1f26}.tpx-select2-container.select2-daq.select2-container-active .select2-choice .select2-arrow{border-left-color:#1d1f26}.tpx-select2-drop.select2-daq{border-color:#1d1f26;background-color:#2d303a}.tpx-select2-drop.select2-daq .select2-search input{border-color:#1d1f26}.tpx-select2-drop.select2-daq .select2-results{color:#fff}.tpx-select2-drop.select2-daq .select2-highlighted{background-color:#000001}.cmb-td .select2-container{width:50%}
+@charset "utf-8";
+/*---------------------------------------------------
+    LESS Elements 0.9
+  ---------------------------------------------------
+    A set of useful LESS mixins
+    More info at: http://lesselements.com
+  ---------------------------------------------------*/
+@font-face {
+  font-family: 'SourceSansProRegular';
+  font-style: normal;
+  font-weight: normal;
+  src: url('../fonts/font_sourcesans-pro/SourceSansPro-Regular-webfont.eot');
+  src: url('../fonts/font_sourcesans-pro/SourceSansPro-Regular-webfont.eot?#iefix') format('embedded-opentype'), url('../fonts/font_sourcesans-pro/SourceSansPro-Regular-webfont.woff') format('woff'), url('../fonts/font_sourcesans-pro/SourceSansPro-Regular-webfont.ttf') format('truetype'), url('../fonts/font_sourcesans-pro/SourceSansPro-Regular-webfont.svg#SourceSansProRegular') format('svg');
+}
+@font-face {
+  font-family: 'SourceSansProBold';
+  font-style: normal;
+  font-weight: normal;
+  src: url('../fonts/font_sourcesans-pro/SourceSansPro-Bold-webfont.eot');
+  src: url('../fonts/font_sourcesans-pro/SourceSansPro-Bold-webfont.eot?#iefix') format('embedded-opentype'), url('../fonts/font_sourcesans-pro/SourceSansPro-Bold-webfont.woff') format('woff'), url('../fonts/font_sourcesans-pro/SourceSansPro-Bold-webfont.ttf') format('truetype'), url('../fonts/font_sourcesans-pro/SourceSansPro-Bold-webfont.svg#SourceSansProBold') format('svg');
+}
+@font-face {
+  font-family: 'SourceSansProLight';
+  font-style: normal;
+  font-weight: normal;
+  src: url('../fonts/font_sourcesans-pro/SourceSansPro-Light-webfont.eot');
+  src: url('../fonts/font_sourcesans-proSource/SansPro-Light-webfont.eot?#iefix') format('embedded-opentype'), url('../fonts/font_sourcesans-pro/SourceSansPro-Light-webfont.woff') format('woff'), url('../fonts/font_sourcesans-pro/SourceSansPro-Light-webfont.ttf') format('truetype'), url('../fonts/font_sourcesans-proSource/SansPro-Light-webfont.svg#SourceSansProLight') format('svg');
+}
+@font-face {
+  font-family: 'SourceSansProSemibold';
+  font-style: normal;
+  font-weight: normal;
+  src: url('../fonts/font_sourcesans-pro/SourceSansPro-Semibold-webfont.eot');
+  src: url('../fonts/font_sourcesans-pro/SourceSansPro-Semibold-webfont.eot?#iefix') format('embedded-opentype'), url('../fonts/font_sourcesans-pro/SourceSansPro-Semibold-webfont.woff') format('woff'), url('../fonts/font_sourcesans-pro/SourceSansPro-Semibold-webfont.ttf') format('truetype'), url('../fonts/font_sourcesans-pro/SourceSansPro-Semibold-webfont.svg#SourceSansProSemibold') format('svg');
+}
+/*! fileicon.css v1.0.0 | MIT License | github.com/picturepan2/fileicon.css */
+/* fileicon.basic */
+.file-icon {
+  font-family: Arial, Tahoma, sans-serif;
+  font-weight: 300;
+  display: block;
+  width: 24px;
+  height: 32px;
+  background: #018FEF;
+  position: relative;
+  border-radius: 2px;
+  text-align: left;
+  -webkit-font-smoothing: antialiased;
+}
+.file-icon::before {
+  display: block;
+  content: "";
+  position: absolute;
+  top: 0;
+  right: 0;
+  width: 0;
+  height: 0;
+  border-bottom-left-radius: 2px;
+  border-width: 5px;
+  border-style: solid;
+  border-color: #ffffff #ffffff rgba(255, 255, 255, 0.35) rgba(255, 255, 255, 0.35);
+}
+.file-icon::after {
+  display: block;
+  content: attr(data-type);
+  position: absolute;
+  bottom: 0;
+  left: 0;
+  font-size: 10px;
+  color: #ffffff;
+  text-transform: lowercase;
+  width: 100%;
+  padding: 2px;
+  white-space: nowrap;
+  overflow: hidden;
+}
+/* fileicons */
+.file-icon-xs {
+  width: 12px;
+  height: 16px;
+  border-radius: 2px;
+}
+.file-icon-xs::before {
+  border-bottom-left-radius: 1px;
+  border-width: 3px;
+}
+.file-icon-xs::after {
+  content: "";
+  border-bottom: 2px solid rgba(255, 255, 255, 0.45);
+  width: auto;
+  left: 2px;
+  right: 2px;
+  bottom: 3px;
+}
+.file-icon-sm {
+  width: 18px;
+  height: 24px;
+  border-radius: 2px;
+}
+.file-icon-sm::before {
+  border-bottom-left-radius: 2px;
+  border-width: 4px;
+}
+.file-icon-sm::after {
+  font-size: 7px;
+  padding: 2px;
+}
+.file-icon-lg {
+  width: 48px;
+  height: 64px;
+  border-radius: 3px;
+}
+.file-icon-lg::before {
+  border-bottom-left-radius: 2px;
+  border-width: 8px;
+}
+.file-icon-lg::after {
+  font-size: 16px;
+  padding: 4px 6px;
+}
+.file-icon-xl {
+  width: 96px;
+  height: 128px;
+  border-radius: 4px;
+}
+.file-icon-xl::before {
+  border-bottom-left-radius: 4px;
+  border-width: 16px;
+}
+.file-icon-xl::after {
+  font-size: 24px;
+  padding: 4px 10px;
+}
+/* fileicon.types */
+.file-icon[data-type=zip],
+.file-icon[data-type=rar] {
+  background: #ACACAC;
+}
+.file-icon[data-type^=doc] {
+  background: #307CF1;
+}
+.file-icon[data-type^=xls] {
+  background: #0F9D58;
+}
+.file-icon[data-type^=ppt] {
+  background: #D24726;
+}
+.file-icon[data-type=pdf] {
+  background: #E13D34;
+}
+.file-icon[data-type=txt] {
+  background: #5EB533;
+}
+.file-icon[data-type=mp3],
+.file-icon[data-type=wma],
+.file-icon[data-type=m4a],
+.file-icon[data-type=flac] {
+  background: #8E44AD;
+}
+.file-icon[data-type=mp4],
+.file-icon[data-type=wmv],
+.file-icon[data-type=mov],
+.file-icon[data-type=avi],
+.file-icon[data-type=mkv] {
+  background: #7A3CE7;
+}
+.file-icon[data-type=bmp],
+.file-icon[data-type=jpg],
+.file-icon[data-type=jpeg],
+.file-icon[data-type=gif],
+.file-icon[data-type=png] {
+  background: #F4B400;
+}
+@font-face {
+  font-family: 'SSStandard';
+  src: url('../fonts/font_ss-standard/ss-standard.eot');
+  src: url('../fonts/font_ss-standard/ss-standard.eot?#iefix') format('embedded-opentype'), url('../fonts/font_ss-standard/ss-standard.woff') format('woff'), url('../fonts/font_ss-standard/ss-standard.ttf') format('truetype'), url('../fonts/font_ss-standard/ss-standard.svg#SourceSansProSemibold') format('svg');
+  font-weight: normal;
+  font-style: normal;
+}
+@font-face {
+  font-family: 'SSSymbol';
+  src: url('../fonts/font_ss-block/ss-symbolicons-block.eot');
+  src: url('../fonts/font_ss-block/ss-symbolicons-block.eot?#iefix') format('embedded-opentype'), url('../fonts/font_ss-block/ss-symbolicons-block.woff') format('woff'), url('../fonts/font_ss-block/ss-symbolicons-block.ttf') format('truetype'), url('../fonts/font_ss-block/ss-symbolicons-block.svg#SourceSansProSemibold') format('svg');
+  font-weight: normal;
+  font-style: normal;
+}
+@font-face {
+  font-family: 'SSSymbolOutline';
+  src: url('../fonts/font_ss-line/ss-symbolicons-line.eot');
+  src: url('../fonts/font_ss-line/ss-symbolicons-line.eot?#iefix') format('embedded-opentype'), url('../fonts/font_ss-line/ss-symbolicons-line.woff') format('woff'), url('../fonts/font_ss-line/ss-symbolicons-line.ttf') format('truetype'), url('../fonts/font_ss-line/ss-symbolicons-line.svg#SSSymbolOutline') format('svg');
+  font-weight: normal;
+  font-style: normal;
+}
+@font-face {
+  font-family: 'SSGlyphishOutlined';
+  src: url('../fonts/font_ss-glyphish-outlined/ss-glyphish-outlined.eot');
+  src: url('../fonts/font_ss-glyphish-outlined/ss-glyphish-outlined.eot?#iefix') format('embedded-opentype'), url('../fonts/font_ss-glyphish-outlined/ss-glyphish-outlined.woff') format('woff'), url('../fonts/font_ss-glyphish-outlined/ss-glyphish-outlined.ttf') format('truetype'), url('../fonts/font_ss-glyphish-outlined/ss-glyphish-outlined.svg#SSSymbolOutline') format('svg');
+  font-weight: normal;
+  font-style: normal;
+}
+@font-face {
+  font-family: 'SSSocial';
+  src: url('../fonts/font_ss-social/ss-social-regular.eot');
+  src: url('../fonts/font_ss-social/ss-social-regular.eot?#iefix') format('embedded-opentype'), url('../fonts/font_ss-social/ss-social-regular.woff') format('woff'), url('../fonts/font_ss-social/ss-social-regular.ttf') format('truetype'), url('../fonts/font_ss-social/ss-social-regular.svg#SSSocialRegular') format('svg');
+  font-weight: normal;
+  font-style: normal;
+}
+.icon {
+  font-family: "SSStandard";
+  font-style: normal;
+  font-weight: normal;
+  text-decoration: none;
+  text-rendering: optimizeLegibility;
+  white-space: nowrap;
+  -webkit-font-feature-settings: "liga";
+  -moz-font-feature-settings: "liga=1";
+  -moz-font-feature-settings: "liga";
+  -ms-font-feature-settings: "liga" 1;
+  -o-font-feature-settings: "liga";
+  font-feature-settings: "liga";
+  -webkit-font-smoothing: antialiased;
+}
+.icon:before {
+  content: attr(data-icon);
+}
+.icon.icon.symbol {
+  font-family: "SSSymbol";
+}
+.icon.icon.symbol_outline {
+  font-family: "SSSymbolOutline";
+}
+.icon.icon.social {
+  font-family: "SSSocial";
+}
+.icon.icon.glyph {
+  font-family: "SSGlyphishOutlined";
+}
+@-webkit-keyframes fadeAfterDisplay {
+  0% {
+    display: none;
+    opacity: 0;
+  }
+  1% {
+    display: inline-block;
+    opacity: 0;
+  }
+  100% {
+    display: inline-block;
+    opacity: 1;
+  }
+}
+.postbox .nav-tabs {
+  background: #00bce3;
+  padding-top: 10px;
+}
+.postbox .nav-tabs li a {
+  border: 0;
+  font-size: 16px;
+  margin-right: 0;
+  padding: 15px;
+  -webkit-border-radius: 0;
+  -moz-border-radius: 0;
+  border-radius: 0;
+  color: #00687d;
+}
+.postbox .nav-tabs li a:hover {
+  background: none;
+  color: #ffffff;
+}
+.postbox .nav-tabs li a:focus {
+  outline: none;
+  background: transparent;
+  box-shadow: none;
+}
+.postbox .nav-tabs li.pull-right {
+  margin-right: 15px;
+  color: #ffffff;
+}
+.postbox .nav-tabs li.pull-right .checkbox {
+  margin: 15px 0 0;
+}
+.postbox .nav-tabs li.pull-right .checkbox label {
+  font-size: 16px;
+}
+.postbox .nav-tabs li.pull-right .checkbox label input {
+  margin-top: 2px;
+}
+.postbox .nav-tabs li.active a {
+  border: 0;
+  color: #ffffff;
+  background: transparent;
+}
+.postbox .nav-tabs li.active a:focus {
+  outline: none;
+  background: transparent;
+  box-shadow: none;
+}
+.postbox .nav-tabs li.active:focus {
+  outline: none;
+  box-shadow: none;
+}
+.postbox .modal-content {
+  background: #ffffff;
+}
+.modal-annotation .modal-dialog {
+  margin-top: 120px;
+}
+.modal-annotation .modal-dialog .modal-content {
+  background: #2f333b;
+  -webkit-border-radius: 0;
+  -moz-border-radius: 0;
+  border-radius: 0;
+}
+.modal-annotation .modal-dialog .modal-content .modal-body {
+  background: #f3f3f3;
+}
+.modal-annotation .modal-dialog .modal-content input {
+  display: block;
+  width: 100%;
+  padding: 10px;
+  margin-bottom: 5px;
+}
+.modal-annotation .modal-dialog .modal-content textarea {
+  width: 100%;
+  padding: 10px;
+}
+.modal-annotation .modal-dialog .modal-content .btn-primary {
+  background: #00bce3;
+}
+#prodaq_documentation_widget {
+  background: #2f333b;
+}
+#prodaq_documentation_widget .inside {
+  padding: 0;
+  margin: 0;
+}
+#prodaq_documentation_widget .prodaq-widget {
+  overflow: auto;
+}
+#prodaq_documentation_widget .prodaq-widget__nav {
+  box-sizing: border-box;
+  float: left;
+  width: 25%;
+  color: #ffffff;
+  border-right: 1px solid #3a3f49;
+}
+#prodaq_documentation_widget .prodaq-widget__nav > li {
+  color: #00bce3;
+  margin-bottom: 5px;
+  font-size: 12px;
+}
+#prodaq_documentation_widget .prodaq-widget__nav > li span {
+  padding: 5px 5px 5px 15px;
+  text-transform: uppercase;
+}
+#prodaq_documentation_widget .prodaq-widget__nav > li ul {
+  padding: 0;
+  margin-top: 5px;
+}
+#prodaq_documentation_widget .prodaq-widget__nav > li ul li a {
+  padding: 5px 15px;
+  display: block;
+  color: #ffffff;
+}
+#prodaq_documentation_widget .prodaq-widget__nav > li ul li a:hover {
+  background: #3a3f49;
+}
+#prodaq_documentation_widget .prodaq-widget__nav > li ul li.active a {
+  background: #ffffff;
+  color: #00bce3;
+}
+#prodaq_documentation_widget .documentation__pane {
+  width: 75%;
+  float: left;
+  box-sizing: border-box;
+  padding: 15px;
+  display: none;
+}
+#prodaq_documentation_widget .documentation__pane.active {
+  display: block;
+}
+#prodaq_documentation_widget .documentation__pane h3 {
+  color: #ffffff;
+}
+#prodaq_documentation_widget .documentation__pane p {
+  color: #ffffff;
+}
+#prodaq_documentation_widget .documentation__pane p a {
+  color: #00bce3;
+}
+#prodaq_documentation_widget .documentation__pane h2 {
+  color: #ffffff;
+  font-size: 18px;
+}
+#prodaq_documentation_widget .documentation__pane span {
+  color: #c272a9;
+  background: #3a3f49;
+  padding: 0 2px;
+  display: block;
+}
+#prodaq_documentation_widget .documentation__pane h4 {
+  text-transform: uppercase;
+  color: #ffffff;
+}
+#prodaq_documentation_widget .documentation__pane .data-keys {
+  height: 250px;
+  overflow-y: scroll;
+  box-shadow: inset 0 -10px 15px -10px rgba(0, 0, 0, 0.4);
+}
+#prodaq_documentation_widget .documentation__pane .data-keys li {
+  color: #c272a9;
+  margin-left: 5px;
+  margin-bottom: 5px;
+}
+#prodaq_documentation_widget .documentation__pane .data-keys li ul {
+  margin-top: 5px;
+}
+#prodaq_documentation_widget .documentation__pane .data-keys li li {
+  padding-left: 10px;
+  color: #A14685;
+}
+#prodaq_documentation_widget .documentation__pane .data-keys li li li {
+  color: #7d3768;
+}
+#prodaq_documentation_widget .hndle.ui-sortable-handle {
+  color: #ffffff;
+  border-bottom: 1px solid #3a3f49;
+}
+#prodaq_dashboard_widget {
+  background: #00bce3;
+  position: relative;
+  overflow: visible;
+}
+#prodaq_dashboard_widget h3 {
+  color: #ffffff;
+  border-bottom: 1px solid #0092b0;
+}
+#prodaq_dashboard_widget .prodaq-widget {
+  transition: all 0.25s ease;
+}
+#prodaq_dashboard_widget .prodaq-widget h2 {
+  color: #ffffff;
+}
+#prodaq_dashboard_widget .prodaq-widget p {
+  color: #ffffff;
+  margin-bottom: 25px;
+}
+#prodaq_dashboard_widget .prodaq-widget > a {
+  padding: 10px 15px;
+  border: 1px solid #ffffff;
+  color: #ffffff;
+}
+#prodaq_dashboard_widget .prodaq-widget > a:hover {
+  background: #00d1fc;
+}
+#prodaq_dashboard_widget .participant__search {
+  width: 100%;
+}
+#prodaq_dashboard_widget .participant-list {
+  position: relative;
+  background: #f4f4f4;
+  width: 100%;
+  margin-top: 0;
+  overflow-y: scroll;
+  height: 0;
+  transition: all 0.25s ease;
+  border-top: 1px solid #00bce3;
+}
+#prodaq_dashboard_widget .participant-list.show {
+  height: 150px;
+}
+#prodaq_dashboard_widget .participant-list li {
+  border-bottom: 1px solid #eee;
+  margin: 0;
+}
+#prodaq_dashboard_widget .participant-list li a {
+  display: block;
+  padding: 10px;
+}
+#prodaq_dashboard_widget .participant-list li:hover {
+  background: #fafafa;
+}
+#prodaq_dashboard_widget .participant-list li.no-results {
+  padding: 10px;
+}
+#prodaq_dashboard_widget input {
+  width: 100%;
+  padding: 10px;
+  margin: 25px 0 0;
+  border: 0;
+}
+#poststuff #_campaign_data_metabox,
+#poststuff #_iteration_data_metabox,
+#poststuff #_participant_data_metabox,
+#poststuff #_persona_data_metabox,
+#poststuff #_product_data_metabox,
+#poststuff #_report_data_metabox,
+#poststuff #_quotes_data_metabox,
+#poststuff #_resource_data_metabox {
+  background: transparent;
+}
+#poststuff #_campaign_data_metabox .inside,
+#poststuff #_iteration_data_metabox .inside,
+#poststuff #_participant_data_metabox .inside,
+#poststuff #_persona_data_metabox .inside,
+#poststuff #_product_data_metabox .inside,
+#poststuff #_report_data_metabox .inside,
+#poststuff #_quotes_data_metabox .inside,
+#poststuff #_resource_data_metabox .inside {
+  padding: 0;
+  margin-top: 0;
+}
+#poststuff #_campaign_data_metabox .hndle.ui-sortable-handle,
+#poststuff #_iteration_data_metabox .hndle.ui-sortable-handle,
+#poststuff #_participant_data_metabox .hndle.ui-sortable-handle,
+#poststuff #_persona_data_metabox .hndle.ui-sortable-handle,
+#poststuff #_product_data_metabox .hndle.ui-sortable-handle,
+#poststuff #_report_data_metabox .hndle.ui-sortable-handle,
+#poststuff #_quotes_data_metabox .hndle.ui-sortable-handle,
+#poststuff #_resource_data_metabox .hndle.ui-sortable-handle {
+  background: #00bce3;
+  color: #ffffff;
+  font-weight: normal;
+  border-bottom: 0;
+  font-size: 24px;
+  font-weight: 200;
+  line-height: 48px;
+  padding-bottom: 0;
+}
+#poststuff #_campaign_data_metabox .form-section,
+#poststuff #_iteration_data_metabox .form-section,
+#poststuff #_participant_data_metabox .form-section,
+#poststuff #_persona_data_metabox .form-section,
+#poststuff #_product_data_metabox .form-section,
+#poststuff #_report_data_metabox .form-section,
+#poststuff #_quotes_data_metabox .form-section,
+#poststuff #_resource_data_metabox .form-section {
+  margin: 15px 0;
+  padding: 15px 15px 30px;
+  border-bottom: 5px solid #ccc;
+  background: #ffffff;
+}
+#poststuff #_campaign_data_metabox .form-section .form-section__flex,
+#poststuff #_iteration_data_metabox .form-section .form-section__flex,
+#poststuff #_participant_data_metabox .form-section .form-section__flex,
+#poststuff #_persona_data_metabox .form-section .form-section__flex,
+#poststuff #_product_data_metabox .form-section .form-section__flex,
+#poststuff #_report_data_metabox .form-section .form-section__flex,
+#poststuff #_quotes_data_metabox .form-section .form-section__flex,
+#poststuff #_resource_data_metabox .form-section .form-section__flex {
+  display: flex;
+  flex-direction: row;
+}
+#poststuff #_campaign_data_metabox .form-section .form-section__flex .form-group,
+#poststuff #_iteration_data_metabox .form-section .form-section__flex .form-group,
+#poststuff #_participant_data_metabox .form-section .form-section__flex .form-group,
+#poststuff #_persona_data_metabox .form-section .form-section__flex .form-group,
+#poststuff #_product_data_metabox .form-section .form-section__flex .form-group,
+#poststuff #_report_data_metabox .form-section .form-section__flex .form-group,
+#poststuff #_quotes_data_metabox .form-section .form-section__flex .form-group,
+#poststuff #_resource_data_metabox .form-section .form-section__flex .form-group {
+  justify-content: space-between;
+  width: 100%;
+  padding: 10px 20px 10px 0;
+}
+#poststuff #_campaign_data_metabox .form-section .form-section__flex .form-group .checkbox,
+#poststuff #_iteration_data_metabox .form-section .form-section__flex .form-group .checkbox,
+#poststuff #_participant_data_metabox .form-section .form-section__flex .form-group .checkbox,
+#poststuff #_persona_data_metabox .form-section .form-section__flex .form-group .checkbox,
+#poststuff #_product_data_metabox .form-section .form-section__flex .form-group .checkbox,
+#poststuff #_report_data_metabox .form-section .form-section__flex .form-group .checkbox,
+#poststuff #_quotes_data_metabox .form-section .form-section__flex .form-group .checkbox,
+#poststuff #_resource_data_metabox .form-section .form-section__flex .form-group .checkbox {
+  margin-top: 30px;
+}
+#poststuff #_campaign_data_metabox .form-section .form-section__flex .form-group .checkbox input,
+#poststuff #_iteration_data_metabox .form-section .form-section__flex .form-group .checkbox input,
+#poststuff #_participant_data_metabox .form-section .form-section__flex .form-group .checkbox input,
+#poststuff #_persona_data_metabox .form-section .form-section__flex .form-group .checkbox input,
+#poststuff #_product_data_metabox .form-section .form-section__flex .form-group .checkbox input,
+#poststuff #_report_data_metabox .form-section .form-section__flex .form-group .checkbox input,
+#poststuff #_quotes_data_metabox .form-section .form-section__flex .form-group .checkbox input,
+#poststuff #_resource_data_metabox .form-section .form-section__flex .form-group .checkbox input {
+  margin-right: 3px;
+}
+#poststuff #_campaign_data_metabox .form-section .form-section__flex .dodelete,
+#poststuff #_iteration_data_metabox .form-section .form-section__flex .dodelete,
+#poststuff #_participant_data_metabox .form-section .form-section__flex .dodelete,
+#poststuff #_persona_data_metabox .form-section .form-section__flex .dodelete,
+#poststuff #_product_data_metabox .form-section .form-section__flex .dodelete,
+#poststuff #_report_data_metabox .form-section .form-section__flex .dodelete,
+#poststuff #_quotes_data_metabox .form-section .form-section__flex .dodelete,
+#poststuff #_resource_data_metabox .form-section .form-section__flex .dodelete {
+  margin-top: 30px;
+}
+#poststuff #_campaign_data_metabox .form-section h2,
+#poststuff #_iteration_data_metabox .form-section h2,
+#poststuff #_participant_data_metabox .form-section h2,
+#poststuff #_persona_data_metabox .form-section h2,
+#poststuff #_product_data_metabox .form-section h2,
+#poststuff #_report_data_metabox .form-section h2,
+#poststuff #_quotes_data_metabox .form-section h2,
+#poststuff #_resource_data_metabox .form-section h2 {
+  color: #2f333b;
+  margin-top: 5px!important;
+  padding: 0;
+  font-size: 18px;
+  line-height: 30px;
+}
+#poststuff #_campaign_data_metabox .form-section .dodelete,
+#poststuff #_iteration_data_metabox .form-section .dodelete,
+#poststuff #_participant_data_metabox .form-section .dodelete,
+#poststuff #_persona_data_metabox .form-section .dodelete,
+#poststuff #_product_data_metabox .form-section .dodelete,
+#poststuff #_report_data_metabox .form-section .dodelete,
+#poststuff #_quotes_data_metabox .form-section .dodelete,
+#poststuff #_resource_data_metabox .form-section .dodelete {
+  position: absolute;
+  right: 15px;
+  color: #ccc;
+  line-height: 40px;
+}
+#poststuff #_campaign_data_metabox .form-section .dodelete:hover,
+#poststuff #_iteration_data_metabox .form-section .dodelete:hover,
+#poststuff #_participant_data_metabox .form-section .dodelete:hover,
+#poststuff #_persona_data_metabox .form-section .dodelete:hover,
+#poststuff #_product_data_metabox .form-section .dodelete:hover,
+#poststuff #_report_data_metabox .form-section .dodelete:hover,
+#poststuff #_quotes_data_metabox .form-section .dodelete:hover,
+#poststuff #_resource_data_metabox .form-section .dodelete:hover {
+  color: #999;
+  text-decoration: none;
+}
+#poststuff #_campaign_data_metabox .form-section a[class^="docopy-"],
+#poststuff #_iteration_data_metabox .form-section a[class^="docopy-"],
+#poststuff #_participant_data_metabox .form-section a[class^="docopy-"],
+#poststuff #_persona_data_metabox .form-section a[class^="docopy-"],
+#poststuff #_product_data_metabox .form-section a[class^="docopy-"],
+#poststuff #_report_data_metabox .form-section a[class^="docopy-"],
+#poststuff #_quotes_data_metabox .form-section a[class^="docopy-"],
+#poststuff #_resource_data_metabox .form-section a[class^="docopy-"],
+#poststuff #_campaign_data_metabox .form-section a[class*=" docopy-"],
+#poststuff #_iteration_data_metabox .form-section a[class*=" docopy-"],
+#poststuff #_participant_data_metabox .form-section a[class*=" docopy-"],
+#poststuff #_persona_data_metabox .form-section a[class*=" docopy-"],
+#poststuff #_product_data_metabox .form-section a[class*=" docopy-"],
+#poststuff #_report_data_metabox .form-section a[class*=" docopy-"],
+#poststuff #_quotes_data_metabox .form-section a[class*=" docopy-"],
+#poststuff #_resource_data_metabox .form-section a[class*=" docopy-"] {
+  width: 100%;
+  text-align: center;
+  line-height: 40px;
+  height: 40px;
+}
+#poststuff #_campaign_data_metabox .form-section .form-group.upload-inline,
+#poststuff #_iteration_data_metabox .form-section .form-group.upload-inline,
+#poststuff #_participant_data_metabox .form-section .form-group.upload-inline,
+#poststuff #_persona_data_metabox .form-section .form-group.upload-inline,
+#poststuff #_product_data_metabox .form-section .form-group.upload-inline,
+#poststuff #_report_data_metabox .form-section .form-group.upload-inline,
+#poststuff #_quotes_data_metabox .form-section .form-group.upload-inline,
+#poststuff #_resource_data_metabox .form-section .form-group.upload-inline {
+  width: 100%;
+}
+#poststuff #_campaign_data_metabox .form-section .form-group.upload-inline input[type="text"],
+#poststuff #_iteration_data_metabox .form-section .form-group.upload-inline input[type="text"],
+#poststuff #_participant_data_metabox .form-section .form-group.upload-inline input[type="text"],
+#poststuff #_persona_data_metabox .form-section .form-group.upload-inline input[type="text"],
+#poststuff #_product_data_metabox .form-section .form-group.upload-inline input[type="text"],
+#poststuff #_report_data_metabox .form-section .form-group.upload-inline input[type="text"],
+#poststuff #_quotes_data_metabox .form-section .form-group.upload-inline input[type="text"],
+#poststuff #_resource_data_metabox .form-section .form-group.upload-inline input[type="text"] {
+  width: 80%;
+  display: inline-block;
+}
+#poststuff #_campaign_data_metabox .form-section .form-group.upload-inline a,
+#poststuff #_iteration_data_metabox .form-section .form-group.upload-inline a,
+#poststuff #_participant_data_metabox .form-section .form-group.upload-inline a,
+#poststuff #_persona_data_metabox .form-section .form-group.upload-inline a,
+#poststuff #_product_data_metabox .form-section .form-group.upload-inline a,
+#poststuff #_report_data_metabox .form-section .form-group.upload-inline a,
+#poststuff #_quotes_data_metabox .form-section .form-group.upload-inline a,
+#poststuff #_resource_data_metabox .form-section .form-group.upload-inline a {
+  width: 19%;
+  text-align: center;
+  display: inline-block;
+  min-height: 36px;
+  line-height: 36px;
+}
+#poststuff #_campaign_data_metabox .form-section .asset-repeatable,
+#poststuff #_iteration_data_metabox .form-section .asset-repeatable,
+#poststuff #_participant_data_metabox .form-section .asset-repeatable,
+#poststuff #_persona_data_metabox .form-section .asset-repeatable,
+#poststuff #_product_data_metabox .form-section .asset-repeatable,
+#poststuff #_report_data_metabox .form-section .asset-repeatable,
+#poststuff #_quotes_data_metabox .form-section .asset-repeatable,
+#poststuff #_resource_data_metabox .form-section .asset-repeatable {
+  border: 1px solid #ccc;
+  margin-bottom: 15px;
+  padding: 15px;
+  position: relative;
+}
+#poststuff #_campaign_data_metabox .form-section .asset-repeatable .form-group,
+#poststuff #_iteration_data_metabox .form-section .asset-repeatable .form-group,
+#poststuff #_participant_data_metabox .form-section .asset-repeatable .form-group,
+#poststuff #_persona_data_metabox .form-section .asset-repeatable .form-group,
+#poststuff #_product_data_metabox .form-section .asset-repeatable .form-group,
+#poststuff #_report_data_metabox .form-section .asset-repeatable .form-group,
+#poststuff #_quotes_data_metabox .form-section .asset-repeatable .form-group,
+#poststuff #_resource_data_metabox .form-section .asset-repeatable .form-group {
+  width: 40%;
+}
+#poststuff #_campaign_data_metabox .form-section .asset-repeatable .form-group.upload-inline input,
+#poststuff #_iteration_data_metabox .form-section .asset-repeatable .form-group.upload-inline input,
+#poststuff #_participant_data_metabox .form-section .asset-repeatable .form-group.upload-inline input,
+#poststuff #_persona_data_metabox .form-section .asset-repeatable .form-group.upload-inline input,
+#poststuff #_product_data_metabox .form-section .asset-repeatable .form-group.upload-inline input,
+#poststuff #_report_data_metabox .form-section .asset-repeatable .form-group.upload-inline input,
+#poststuff #_quotes_data_metabox .form-section .asset-repeatable .form-group.upload-inline input,
+#poststuff #_resource_data_metabox .form-section .asset-repeatable .form-group.upload-inline input {
+  width: 45%;
+}
+#poststuff #_campaign_data_metabox .form-section .asset-repeatable .form-group.upload-inline a,
+#poststuff #_iteration_data_metabox .form-section .asset-repeatable .form-group.upload-inline a,
+#poststuff #_participant_data_metabox .form-section .asset-repeatable .form-group.upload-inline a,
+#poststuff #_persona_data_metabox .form-section .asset-repeatable .form-group.upload-inline a,
+#poststuff #_product_data_metabox .form-section .asset-repeatable .form-group.upload-inline a,
+#poststuff #_report_data_metabox .form-section .asset-repeatable .form-group.upload-inline a,
+#poststuff #_quotes_data_metabox .form-section .asset-repeatable .form-group.upload-inline a,
+#poststuff #_resource_data_metabox .form-section .asset-repeatable .form-group.upload-inline a {
+  width: auto;
+}
+#poststuff #_campaign_data_metabox .form-section .grid-repeatable,
+#poststuff #_iteration_data_metabox .form-section .grid-repeatable,
+#poststuff #_participant_data_metabox .form-section .grid-repeatable,
+#poststuff #_persona_data_metabox .form-section .grid-repeatable,
+#poststuff #_product_data_metabox .form-section .grid-repeatable,
+#poststuff #_report_data_metabox .form-section .grid-repeatable,
+#poststuff #_quotes_data_metabox .form-section .grid-repeatable,
+#poststuff #_resource_data_metabox .form-section .grid-repeatable {
+  border: 1px solid #ccc;
+  margin-bottom: 15px;
+  padding: 15px;
+  position: relative;
+}
+#poststuff #_campaign_data_metabox .form-section .grid-repeatable .dodelete,
+#poststuff #_iteration_data_metabox .form-section .grid-repeatable .dodelete,
+#poststuff #_participant_data_metabox .form-section .grid-repeatable .dodelete,
+#poststuff #_persona_data_metabox .form-section .grid-repeatable .dodelete,
+#poststuff #_product_data_metabox .form-section .grid-repeatable .dodelete,
+#poststuff #_report_data_metabox .form-section .grid-repeatable .dodelete,
+#poststuff #_quotes_data_metabox .form-section .grid-repeatable .dodelete,
+#poststuff #_resource_data_metabox .form-section .grid-repeatable .dodelete {
+  top: 0;
+}
+#poststuff #_campaign_data_metabox .form-section .goal-repeatable .form-group input[type="text"],
+#poststuff #_iteration_data_metabox .form-section .goal-repeatable .form-group input[type="text"],
+#poststuff #_participant_data_metabox .form-section .goal-repeatable .form-group input[type="text"],
+#poststuff #_persona_data_metabox .form-section .goal-repeatable .form-group input[type="text"],
+#poststuff #_product_data_metabox .form-section .goal-repeatable .form-group input[type="text"],
+#poststuff #_report_data_metabox .form-section .goal-repeatable .form-group input[type="text"],
+#poststuff #_quotes_data_metabox .form-section .goal-repeatable .form-group input[type="text"],
+#poststuff #_resource_data_metabox .form-section .goal-repeatable .form-group input[type="text"] {
+  width: 95%;
+}
+#poststuff #_campaign_data_metabox .form-section .ndaq-repeatable,
+#poststuff #_iteration_data_metabox .form-section .ndaq-repeatable,
+#poststuff #_participant_data_metabox .form-section .ndaq-repeatable,
+#poststuff #_persona_data_metabox .form-section .ndaq-repeatable,
+#poststuff #_product_data_metabox .form-section .ndaq-repeatable,
+#poststuff #_report_data_metabox .form-section .ndaq-repeatable,
+#poststuff #_quotes_data_metabox .form-section .ndaq-repeatable,
+#poststuff #_resource_data_metabox .form-section .ndaq-repeatable {
+  border: 1px solid #ccc;
+  position: relative;
+  margin-bottom: 15px;
+}
+#poststuff #_campaign_data_metabox .form-section .ndaq-repeatable .ndaq-repeatable__header,
+#poststuff #_iteration_data_metabox .form-section .ndaq-repeatable .ndaq-repeatable__header,
+#poststuff #_participant_data_metabox .form-section .ndaq-repeatable .ndaq-repeatable__header,
+#poststuff #_persona_data_metabox .form-section .ndaq-repeatable .ndaq-repeatable__header,
+#poststuff #_product_data_metabox .form-section .ndaq-repeatable .ndaq-repeatable__header,
+#poststuff #_report_data_metabox .form-section .ndaq-repeatable .ndaq-repeatable__header,
+#poststuff #_quotes_data_metabox .form-section .ndaq-repeatable .ndaq-repeatable__header,
+#poststuff #_resource_data_metabox .form-section .ndaq-repeatable .ndaq-repeatable__header {
+  overflow: auto;
+  padding: 10px 15px;
+  cursor: pointer;
+  position: relative;
+  z-index: 100;
+}
+#poststuff #_campaign_data_metabox .form-section .ndaq-repeatable .ndaq-repeatable__header h2,
+#poststuff #_iteration_data_metabox .form-section .ndaq-repeatable .ndaq-repeatable__header h2,
+#poststuff #_participant_data_metabox .form-section .ndaq-repeatable .ndaq-repeatable__header h2,
+#poststuff #_persona_data_metabox .form-section .ndaq-repeatable .ndaq-repeatable__header h2,
+#poststuff #_product_data_metabox .form-section .ndaq-repeatable .ndaq-repeatable__header h2,
+#poststuff #_report_data_metabox .form-section .ndaq-repeatable .ndaq-repeatable__header h2,
+#poststuff #_quotes_data_metabox .form-section .ndaq-repeatable .ndaq-repeatable__header h2,
+#poststuff #_resource_data_metabox .form-section .ndaq-repeatable .ndaq-repeatable__header h2 {
+  margin: 0 15px 0 0!important;
+  float: left;
+  line-height: 40px;
+}
+#poststuff #_campaign_data_metabox .form-section .ndaq-repeatable .ndaq-repeatable__header .checkbox,
+#poststuff #_iteration_data_metabox .form-section .ndaq-repeatable .ndaq-repeatable__header .checkbox,
+#poststuff #_participant_data_metabox .form-section .ndaq-repeatable .ndaq-repeatable__header .checkbox,
+#poststuff #_persona_data_metabox .form-section .ndaq-repeatable .ndaq-repeatable__header .checkbox,
+#poststuff #_product_data_metabox .form-section .ndaq-repeatable .ndaq-repeatable__header .checkbox,
+#poststuff #_report_data_metabox .form-section .ndaq-repeatable .ndaq-repeatable__header .checkbox,
+#poststuff #_quotes_data_metabox .form-section .ndaq-repeatable .ndaq-repeatable__header .checkbox,
+#poststuff #_resource_data_metabox .form-section .ndaq-repeatable .ndaq-repeatable__header .checkbox {
+  margin-top: 12px;
+}
+#poststuff #_campaign_data_metabox .form-section .ndaq-repeatable .ndaq-repeatable__header select,
+#poststuff #_iteration_data_metabox .form-section .ndaq-repeatable .ndaq-repeatable__header select,
+#poststuff #_participant_data_metabox .form-section .ndaq-repeatable .ndaq-repeatable__header select,
+#poststuff #_persona_data_metabox .form-section .ndaq-repeatable .ndaq-repeatable__header select,
+#poststuff #_product_data_metabox .form-section .ndaq-repeatable .ndaq-repeatable__header select,
+#poststuff #_report_data_metabox .form-section .ndaq-repeatable .ndaq-repeatable__header select,
+#poststuff #_quotes_data_metabox .form-section .ndaq-repeatable .ndaq-repeatable__header select,
+#poststuff #_resource_data_metabox .form-section .ndaq-repeatable .ndaq-repeatable__header select {
+  margin-top: 8px;
+}
+#poststuff #_campaign_data_metabox .form-section .ndaq-repeatable .ndaq-repeatable__header input,
+#poststuff #_iteration_data_metabox .form-section .ndaq-repeatable .ndaq-repeatable__header input,
+#poststuff #_participant_data_metabox .form-section .ndaq-repeatable .ndaq-repeatable__header input,
+#poststuff #_persona_data_metabox .form-section .ndaq-repeatable .ndaq-repeatable__header input,
+#poststuff #_product_data_metabox .form-section .ndaq-repeatable .ndaq-repeatable__header input,
+#poststuff #_report_data_metabox .form-section .ndaq-repeatable .ndaq-repeatable__header input,
+#poststuff #_quotes_data_metabox .form-section .ndaq-repeatable .ndaq-repeatable__header input,
+#poststuff #_resource_data_metabox .form-section .ndaq-repeatable .ndaq-repeatable__header input {
+  margin-top: 8px;
+}
+#poststuff #_campaign_data_metabox .form-section .ndaq-repeatable .ndaq-repeatable__header .form-group,
+#poststuff #_iteration_data_metabox .form-section .ndaq-repeatable .ndaq-repeatable__header .form-group,
+#poststuff #_participant_data_metabox .form-section .ndaq-repeatable .ndaq-repeatable__header .form-group,
+#poststuff #_persona_data_metabox .form-section .ndaq-repeatable .ndaq-repeatable__header .form-group,
+#poststuff #_product_data_metabox .form-section .ndaq-repeatable .ndaq-repeatable__header .form-group,
+#poststuff #_report_data_metabox .form-section .ndaq-repeatable .ndaq-repeatable__header .form-group,
+#poststuff #_quotes_data_metabox .form-section .ndaq-repeatable .ndaq-repeatable__header .form-group,
+#poststuff #_resource_data_metabox .form-section .ndaq-repeatable .ndaq-repeatable__header .form-group {
+  margin: 0 15px;
+}
+#poststuff #_campaign_data_metabox .form-section .ndaq-repeatable .ndaq-repeatable__body,
+#poststuff #_iteration_data_metabox .form-section .ndaq-repeatable .ndaq-repeatable__body,
+#poststuff #_participant_data_metabox .form-section .ndaq-repeatable .ndaq-repeatable__body,
+#poststuff #_persona_data_metabox .form-section .ndaq-repeatable .ndaq-repeatable__body,
+#poststuff #_product_data_metabox .form-section .ndaq-repeatable .ndaq-repeatable__body,
+#poststuff #_report_data_metabox .form-section .ndaq-repeatable .ndaq-repeatable__body,
+#poststuff #_quotes_data_metabox .form-section .ndaq-repeatable .ndaq-repeatable__body,
+#poststuff #_resource_data_metabox .form-section .ndaq-repeatable .ndaq-repeatable__body {
+  display: none;
+  padding: 25px 15px;
+  background: #f4f4f7;
+  border-top: 1px solid #ccc;
+}
+#poststuff #_campaign_data_metabox .form-section .ndaq-repeatable .ndaq-repeatable__body.active,
+#poststuff #_iteration_data_metabox .form-section .ndaq-repeatable .ndaq-repeatable__body.active,
+#poststuff #_participant_data_metabox .form-section .ndaq-repeatable .ndaq-repeatable__body.active,
+#poststuff #_persona_data_metabox .form-section .ndaq-repeatable .ndaq-repeatable__body.active,
+#poststuff #_product_data_metabox .form-section .ndaq-repeatable .ndaq-repeatable__body.active,
+#poststuff #_report_data_metabox .form-section .ndaq-repeatable .ndaq-repeatable__body.active,
+#poststuff #_quotes_data_metabox .form-section .ndaq-repeatable .ndaq-repeatable__body.active,
+#poststuff #_resource_data_metabox .form-section .ndaq-repeatable .ndaq-repeatable__body.active {
+  display: block;
+}
+#poststuff #_campaign_data_metabox .form-section .ndaq-repeatable .ndaq-repeatable__body .col-md-5 .upload-inline input,
+#poststuff #_iteration_data_metabox .form-section .ndaq-repeatable .ndaq-repeatable__body .col-md-5 .upload-inline input,
+#poststuff #_participant_data_metabox .form-section .ndaq-repeatable .ndaq-repeatable__body .col-md-5 .upload-inline input,
+#poststuff #_persona_data_metabox .form-section .ndaq-repeatable .ndaq-repeatable__body .col-md-5 .upload-inline input,
+#poststuff #_product_data_metabox .form-section .ndaq-repeatable .ndaq-repeatable__body .col-md-5 .upload-inline input,
+#poststuff #_report_data_metabox .form-section .ndaq-repeatable .ndaq-repeatable__body .col-md-5 .upload-inline input,
+#poststuff #_quotes_data_metabox .form-section .ndaq-repeatable .ndaq-repeatable__body .col-md-5 .upload-inline input,
+#poststuff #_resource_data_metabox .form-section .ndaq-repeatable .ndaq-repeatable__body .col-md-5 .upload-inline input {
+  width: 54%;
+}
+#poststuff #_campaign_data_metabox .form-section .ndaq-repeatable .ndaq-repeatable__body .col-md-5 .upload-inline a,
+#poststuff #_iteration_data_metabox .form-section .ndaq-repeatable .ndaq-repeatable__body .col-md-5 .upload-inline a,
+#poststuff #_participant_data_metabox .form-section .ndaq-repeatable .ndaq-repeatable__body .col-md-5 .upload-inline a,
+#poststuff #_persona_data_metabox .form-section .ndaq-repeatable .ndaq-repeatable__body .col-md-5 .upload-inline a,
+#poststuff #_product_data_metabox .form-section .ndaq-repeatable .ndaq-repeatable__body .col-md-5 .upload-inline a,
+#poststuff #_report_data_metabox .form-section .ndaq-repeatable .ndaq-repeatable__body .col-md-5 .upload-inline a,
+#poststuff #_quotes_data_metabox .form-section .ndaq-repeatable .ndaq-repeatable__body .col-md-5 .upload-inline a,
+#poststuff #_resource_data_metabox .form-section .ndaq-repeatable .ndaq-repeatable__body .col-md-5 .upload-inline a {
+  width: auto;
+}
+#poststuff #_campaign_data_metabox .form-section .form-group label,
+#poststuff #_iteration_data_metabox .form-section .form-group label,
+#poststuff #_participant_data_metabox .form-section .form-group label,
+#poststuff #_persona_data_metabox .form-section .form-group label,
+#poststuff #_product_data_metabox .form-section .form-group label,
+#poststuff #_report_data_metabox .form-section .form-group label,
+#poststuff #_quotes_data_metabox .form-section .form-group label,
+#poststuff #_resource_data_metabox .form-section .form-group label {
+  display: block;
+}
+#poststuff #_campaign_data_metabox .form-section .form-group textarea,
+#poststuff #_iteration_data_metabox .form-section .form-group textarea,
+#poststuff #_participant_data_metabox .form-section .form-group textarea,
+#poststuff #_persona_data_metabox .form-section .form-group textarea,
+#poststuff #_product_data_metabox .form-section .form-group textarea,
+#poststuff #_report_data_metabox .form-section .form-group textarea,
+#poststuff #_quotes_data_metabox .form-section .form-group textarea,
+#poststuff #_resource_data_metabox .form-section .form-group textarea,
+#poststuff #_campaign_data_metabox .form-section .form-group input[type="text"],
+#poststuff #_iteration_data_metabox .form-section .form-group input[type="text"],
+#poststuff #_participant_data_metabox .form-section .form-group input[type="text"],
+#poststuff #_persona_data_metabox .form-section .form-group input[type="text"],
+#poststuff #_product_data_metabox .form-section .form-group input[type="text"],
+#poststuff #_report_data_metabox .form-section .form-group input[type="text"],
+#poststuff #_quotes_data_metabox .form-section .form-group input[type="text"],
+#poststuff #_resource_data_metabox .form-section .form-group input[type="text"] {
+  width: 100%;
+}
+#poststuff #_campaign_data_metabox .form-section .form-group input[type="text"],
+#poststuff #_iteration_data_metabox .form-section .form-group input[type="text"],
+#poststuff #_participant_data_metabox .form-section .form-group input[type="text"],
+#poststuff #_persona_data_metabox .form-section .form-group input[type="text"],
+#poststuff #_product_data_metabox .form-section .form-group input[type="text"],
+#poststuff #_report_data_metabox .form-section .form-group input[type="text"],
+#poststuff #_quotes_data_metabox .form-section .form-group input[type="text"],
+#poststuff #_resource_data_metabox .form-section .form-group input[type="text"] {
+  padding: 8px;
+}
+#poststuff #_campaign_data_metabox .form-section .form-group .checkbox input,
+#poststuff #_iteration_data_metabox .form-section .form-group .checkbox input,
+#poststuff #_participant_data_metabox .form-section .form-group .checkbox input,
+#poststuff #_persona_data_metabox .form-section .form-group .checkbox input,
+#poststuff #_product_data_metabox .form-section .form-group .checkbox input,
+#poststuff #_report_data_metabox .form-section .form-group .checkbox input,
+#poststuff #_quotes_data_metabox .form-section .form-group .checkbox input,
+#poststuff #_resource_data_metabox .form-section .form-group .checkbox input {
+  margin-top: 0;
+}
+#poststuff #_campaign_data_metabox .form-section .form-group .thumb-container,
+#poststuff #_iteration_data_metabox .form-section .form-group .thumb-container,
+#poststuff #_participant_data_metabox .form-section .form-group .thumb-container,
+#poststuff #_persona_data_metabox .form-section .form-group .thumb-container,
+#poststuff #_product_data_metabox .form-section .form-group .thumb-container,
+#poststuff #_report_data_metabox .form-section .form-group .thumb-container,
+#poststuff #_quotes_data_metabox .form-section .form-group .thumb-container,
+#poststuff #_resource_data_metabox .form-section .form-group .thumb-container {
+  width: 50px;
+  height: 50px;
+  margin: 5px 0;
+  border: 1px solid #ccc;
+}
+#poststuff #_campaign_data_metabox .form-section .form-group .thumb-container img,
+#poststuff #_iteration_data_metabox .form-section .form-group .thumb-container img,
+#poststuff #_participant_data_metabox .form-section .form-group .thumb-container img,
+#poststuff #_persona_data_metabox .form-section .form-group .thumb-container img,
+#poststuff #_product_data_metabox .form-section .form-group .thumb-container img,
+#poststuff #_report_data_metabox .form-section .form-group .thumb-container img,
+#poststuff #_quotes_data_metabox .form-section .form-group .thumb-container img,
+#poststuff #_resource_data_metabox .form-section .form-group .thumb-container img {
+  width: 100%;
+}
+#poststuff #_campaign_data_metabox .form-section .select2-container,
+#poststuff #_iteration_data_metabox .form-section .select2-container,
+#poststuff #_participant_data_metabox .form-section .select2-container,
+#poststuff #_persona_data_metabox .form-section .select2-container,
+#poststuff #_product_data_metabox .form-section .select2-container,
+#poststuff #_report_data_metabox .form-section .select2-container,
+#poststuff #_quotes_data_metabox .form-section .select2-container,
+#poststuff #_resource_data_metabox .form-section .select2-container {
+  width: 100%;
+}
+#poststuff #_campaign_data_metabox .form-section .select2-container input[type="text"],
+#poststuff #_iteration_data_metabox .form-section .select2-container input[type="text"],
+#poststuff #_participant_data_metabox .form-section .select2-container input[type="text"],
+#poststuff #_persona_data_metabox .form-section .select2-container input[type="text"],
+#poststuff #_product_data_metabox .form-section .select2-container input[type="text"],
+#poststuff #_report_data_metabox .form-section .select2-container input[type="text"],
+#poststuff #_quotes_data_metabox .form-section .select2-container input[type="text"],
+#poststuff #_resource_data_metabox .form-section .select2-container input[type="text"] {
+  padding: 5px;
+}
+#poststuff #_campaign_data_metabox .form-section .select2-container .select2-choice abbr,
+#poststuff #_iteration_data_metabox .form-section .select2-container .select2-choice abbr,
+#poststuff #_participant_data_metabox .form-section .select2-container .select2-choice abbr,
+#poststuff #_persona_data_metabox .form-section .select2-container .select2-choice abbr,
+#poststuff #_product_data_metabox .form-section .select2-container .select2-choice abbr,
+#poststuff #_report_data_metabox .form-section .select2-container .select2-choice abbr,
+#poststuff #_quotes_data_metabox .form-section .select2-container .select2-choice abbr,
+#poststuff #_resource_data_metabox .form-section .select2-container .select2-choice abbr {
+  right: 35px;
+  top: 9px;
+}
+#poststuff .participants {
+  overflow: auto;
+}
+#poststuff .participants .participants__list {
+  float: left;
+  width: 25%;
+  padding-top: 15px;
+}
+#poststuff .participants .participants__list li {
+  min-height: 80px;
+  padding-right: 10px;
+}
+#poststuff .row-with-thumb {
+  border-top: 1px solid #ccc;
+  padding: 10px 0;
+  background: #fafafa;
+}
+#poststuff .row-with-thumb:last-of-type {
+  border-bottom: 1px solid #ccc;
+  margin-bottom: 15px;
+}
+#poststuff .row-with-thumb .hidden-input {
+  width: 100%;
+  position: relative;
+}
+#poststuff .row-with-thumb .hidden-input a {
+  position: absolute;
+  width: 100%;
+  top: 0;
+  box-sizing: border-box;
+  text-align: center;
+  line-height: 36px;
+  height: 36px;
+}
+#poststuff .row-with-thumb .hidden-input input {
+  position: absolute;
+  top: 0;
+  border: 0;
+}
+#poststuff .row-with-thumb .hidden-input .preview-wrapper {
+  margin-top: 25px;
+}
+#poststuff .preview-wrapper {
+  position: relative;
+}
+#poststuff .preview-wrapper img {
+  width: 100%;
+}
+#poststuff .target {
+  position: absolute;
+  height: 40px;
+  width: 40px;
+  border: 4px dashed #e223db;
+}
+#poststuff .target a {
+  background: #2f333b;
+  border-bottom: 1px solid #ffffff;
+  color: #ffffff;
+  padding: 5px;
+  width: auto!important;
+  line-height: 15px!important;
+  min-height: 15px!important;
+  position: relative;
+  display: block!important;
+  right: -38px;
+  top: -8px;
+  text-align: center;
+}
+#poststuff .target a:hover {
+  color: #e223db;
+}
+#poststuff .target a:last-of-type {
+  border: none;
+}
+#poststuff .target a.remove {
+  bottom: 0;
+}
+#poststuff .annotationArr:read-only {
+  background: #2f333b;
+  border: none;
+  color: #515866;
+  padding: 10px;
+}
+#_iteration_data_metabox .inside {
+  padding: 0;
+  margin: 0;
+}
+#_iteration_data_metabox .iteration__header {
+  background: #f4f4f5;
+  padding: 15px;
+  border-bottom: 1px solid #ccc;
+  position: relative;
+}
+#_iteration_data_metabox .iteration__header .form-group {
+  margin: 0;
+}
+#_iteration_data_metabox .iteration__header .form-group .select2-container {
+  width: 200px;
+  margin-left: 15px;
+}
+#_iteration_data_metabox .iteration__header a.help {
+  position: absolute;
+  right: 10px;
+  top: 20px;
+  display: block;
+  width: 24px;
+  height: 24px;
+  text-align: center;
+  line-height: 24px;
+  background: #96979c;
+  -webkit-border-radius: 50%;
+  -moz-border-radius: 50%;
+  border-radius: 50%;
+  color: #ffffff;
+}
+#_iteration_data_metabox .iteration__pane {
+  display: none;
+}
+#_iteration_data_metabox .iteration__pane.active {
+  display: block;
+}
+#_iteration_data_metabox .iteration__pane h2 {
+  padding-left: 0;
+  font-size: 18px;
+}
+#_iteration_data_metabox .iteration__pane .docopy-images {
+  width: 100%;
+  box-shadow: none;
+  line-height: 40px;
+  height: 40px;
+  text-align: center;
+}
+#_iteration_data_metabox .iteration__pane .form-section {
+  position: relative;
+}
+#_iteration_data_metabox .iteration__pane .form-section .dodelete {
+  top: 0;
+  right: 0!important;
+  font-size: 16px;
+  background: #6B6d75;
+  width: 30px;
+  text-align: center;
+  line-height: 30px!important;
+  height: 30px;
+}
+#_iteration_data_metabox .iteration__pane .form-section .preview-wrapper {
+  margin-top: 10px;
+}
+#_iteration_data_metabox .iteration__pane .form-section .form-group {
+  margin-top: 15px;
+}
+#_iteration_data_metabox .iteration__pane.iteration__element {
+  padding: 0;
+}
+#_iteration_data_metabox .iteration__pane.iteration__element .nav-tabs {
+  padding-top: 0;
+}
+#_iteration_data_metabox .iteration__pane.iteration__element .nav-tabs li.active a {
+  border-top: 0;
+}
+#iteration-help .modal-body ul > li {
+  margin: 10px 0;
+}
+#iteration-help .modal-body ul > li > ul {
+  padding-left: 20px;
+}
+#_product_data_metabox .download-template li {
+  display: none;
+  padding: 15px 0;
+  font-size: 16px;
+}
+#_product_data_metabox .download-template li img {
+  margin-right: 5px;
+}
+#_product_data_metabox .download-template li.active {
+  display: block;
+}
+#_report_data_metabox #images .form-section {
+  position: relative;
+}
+#_report_data_metabox #images .form-section .dodelete {
+  top: 0;
+  right: 0!important;
+  font-size: 14px;
+  background: #6B6d75;
+  width: 30px;
+  text-align: center;
+  line-height: 30px!important;
+  height: 30px;
+}
+#_report_data_metabox #images .form-section .preview-wrapper {
+  margin-top: 10px;
+}
+#_report_data_metabox #images .form-section .form-group {
+  margin-top: 15px;
+}
+#_report_data_metabox #images .docopy-images {
+  width: 100%;
+  box-shadow: none;
+  line-height: 40px;
+  height: 40px;
+  text-align: center;
+}
+#_resource_data_metabox .ndaq-repeatable__header .form-group {
+  margin-left: 0;
+  margin-right: 50px;
+}
+#_resource_data_metabox .ndaq-repeatable__header .form-group input {
+  margin-top: 0;
+}
+#_resource_data_metabox .ndaq-repeatable__header .dodelete {
+  top: 10px;
+}
+html,
+body {
+  background: #e3e6ed;
+}
+.post-type-participant .wp-list-table .column-featured_image,
+.post-type-persona .wp-list-table .column-featured_image {
+  width: 100px;
+}
+#adminmenuback,
+#adminmenu,
+#adminmenuwrap {
+  background-color: #2d303a;
+}
+#wp-content-editor-tools {
+  background: #e3e6ed;
+}
+#dashboard-widgets-wrap {
+  overflow: visible;
+}
+#adminmenu li.wp-has-current-submenu .wp-submenu {
+  background-color: #1d1f25;
+}
+#adminmenu li.wp-has-current-submenu a.wp-has-current-submenu {
+  background: #1d1f25;
+  color: #00bce3;
+}
+#adminmenu .menu-icon-persona {
+  background: #262930;
+}
+#adminmenu .menu-icon-persona div.wp-menu-image:before {
+  content: "\f337";
+  color: #00bce3;
+}
+#adminmenu .menu-icon-campaign {
+  background: #262930;
+}
+#adminmenu .menu-icon-campaign div.wp-menu-image:before {
+  content: "\f183";
+  color: #00bce3;
+}
+#adminmenu .menu-icon-question {
+  background: #262930;
+}
+#adminmenu .menu-icon-question div.wp-menu-image:before {
+  content: "\f130";
+  color: #00bce3;
+}
+#adminmenu .menu-icon-product {
+  background: #262930;
+}
+#adminmenu .menu-icon-product div.wp-menu-image:before {
+  content: "\f115";
+  color: #00bce3;
+}
+#adminmenu .menu-icon-report {
+  background: #262930;
+  border-bottom: 1px solid #1d1f24;
+}
+#adminmenu .menu-icon-report div.wp-menu-image:before {
+  content: "\f180";
+  color: #00bce3;
+}
+#adminmenu .menu-icon-quote {
+  background: #262930;
+  border-bottom: 1px solid #1d1f24;
+}
+#adminmenu .menu-icon-quote div.wp-menu-image:before {
+  content: "\f122";
+  color: #00bce3;
+}
+#adminmenu li.menu-icon-participant {
+  background: #262930;
+  border-top: 1px solid #1d1f24;
+  margin-top: 10px;
+}
+#adminmenu li.menu-icon-participant div.wp-menu-image:before {
+  content: "\f307";
+  color: #00bce3;
+}
+#adminmenu li.menu-icon-iteration {
+  background: #262930;
+}
+#adminmenu li.menu-icon-iteration div.wp-menu-image:before {
+  content: "\f232";
+  color: #00bce3;
+}
+#wpadminbar {
+  background: #2d303a;
+}
+.select2-results .select2-no-results {
+  background: #2d303a;
+}
+.select2-search-choice-close {
+  background-image: none!important;
+}
+.select2-search {
+  background-image: none!important;
+}
+.tpx-select2-container.select2-daq .select2-choice {
+  border-color: #2d303a;
+  background-color: #2d303a;
+  box-shadow: none;
+  color: #fff;
+}
+.tpx-select2-container.select2-daq .select2-choice .select2-arrow {
+  border-left-color: #2d303a;
+  background-color: #2d303a;
+  color: #fff;
+}
+.tpx-select2-container.select2-daq .select2-default .select2-chosen {
+  color: rgba(255, 255, 255, 0.5);
+}
+.tpx-select2-container.select2-daq.select2-container-multi .select2-choices .select2-search-choice {
+  border-color: #22242c;
+  background-color: #2d303a;
+  color: #fff;
+}
+.tpx-select2-container.select2-daq.select2-container-multi .select2-choices .select2-search-choice:before {
+  color: rgba(255, 255, 255, 0.5);
+}
+.tpx-select2-container.select2-daq.select2-container-active .select2-choice {
+  border-color: #1d1f26;
+}
+.tpx-select2-container.select2-daq.select2-container-active .select2-choice .select2-arrow {
+  border-left-color: #1d1f26;
+}
+.tpx-select2-drop.select2-daq {
+  border-color: #1d1f26;
+  background-color: #2d303a;
+}
+.tpx-select2-drop.select2-daq .select2-search input {
+  border-color: #1d1f26;
+}
+.tpx-select2-drop.select2-daq .select2-results {
+  color: #fff;
+}
+.tpx-select2-drop.select2-daq .select2-highlighted {
+  background-color: #000001;
+}
+.cmb-td .select2-container {
+  width: 50%;
+}

--- a/prodaq/library/less/admin/metabox/common.less
+++ b/prodaq/library/less/admin/metabox/common.less
@@ -204,6 +204,18 @@
 			}
 		}
 	}
+	.participants{
+		overflow: auto;
+		.participants__list{
+			float: left;
+			width: 25%;
+			padding-top: 15px;
+			li{
+				min-height: 80px;
+				padding-right: 10px;
+			}
+		}
+	}
 	.row-with-thumb{
 		border-top: 1px solid #ccc;
 		padding: 10px 0;

--- a/prodaq/templates/page-home.php
+++ b/prodaq/templates/page-home.php
@@ -16,8 +16,8 @@ Template Name: Home Page Template
 				<?php endwhile; ?>
 				<?php endif; ?>
 				<ul>
-					<li><a href="/work/campaigns" class="btn btn-white">Research Campaigns</a></li>
-					<li><a href="/work/personas" class="btn btn-white">Personas</a></li>
+					<li><a href="<?php echo site_url(); ?>/campaigns" class="btn btn-white">Research Campaigns</a></li>
+					<li><a href="<?php echo site_url(); ?>/personas" class="btn btn-white">Personas</a></li>
 				</ul>
 			</div>
 		</div>


### PR DESCRIPTION
* Originally we had to add participants to campaigns and personas manually in order to connect them to each other. This was so we didn’t have to run the participant loop on the front end (to check every participant for relevant meetings or personas). Now we’re just going to pull them in automatically and update the post meta accordingly. It’s a hefty loop if there are a lot of participants but we’re at least confining it to the backend where it matters less. 
* Updating relative path links to `<?php echo site_url(); ?>` so site doesn’t need to be in a work folder. Thanks @jwd2a for spotting this. I’m sure this will need to be updated elsewhere.