### PR TITLE
remove height: 100%

### DIFF
--- a/prodaq/library/less/prodaq/common.less
+++ b/prodaq/library/less/prodaq/common.less
@@ -3,7 +3,6 @@ html,
 body {
 	margin:0;
 	padding:0;
-	height:100%;
 	background:@graybg;
 }
 body.search-open{


### PR DESCRIPTION
giving html and body height: 100% limits the height of the body to 100vh, which causes some ugly problems on pages with content that extends below the fold.